### PR TITLE
feat(registry): improve registry install form

### DIFF
--- a/renderer/src/common/components/ui/alert.tsx
+++ b/renderer/src/common/components/ui/alert.tsx
@@ -1,0 +1,67 @@
+import * as React from 'react'
+import { cva, type VariantProps } from 'class-variance-authority'
+
+import { cn } from '@/common/lib/utils'
+
+const alertVariants = cva(
+  'relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current',
+  {
+    variants: {
+      variant: {
+        default: 'bg-card text-card-foreground',
+        destructive:
+          'text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<'div'> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        'col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        `text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm
+        [&_p]:leading-relaxed`,
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -2,14 +2,20 @@ import type {
   RegistryEnvVar,
   RegistryImageMetadata,
 } from '@/common/api/generated'
-import { render, screen, waitFor } from '@testing-library/react'
-import { it, expect } from 'vitest'
+import { render, screen, waitFor, act } from '@testing-library/react'
+import { it, expect, vi, describe, beforeEach } from 'vitest'
 import { FormRunFromRegistry } from '../form-run-from-registry'
 import userEvent from '@testing-library/user-event'
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
 import { server } from '@/common/mocks/node'
 import { http, HttpResponse } from 'msw'
 import { mswEndpoint } from '@/common/mocks/msw-endpoint'
+import { useRunFromRegistry } from '../../hooks/use-run-from-registry'
+
+// Mock the hook
+vi.mock('../../hooks/use-run-from-registry.tsx', () => ({
+  useRunFromRegistry: vi.fn(),
+}))
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -76,324 +82,636 @@ const ENV_VARS_REQUIRED = [
   },
 ] as const satisfies RegistryEnvVar[]
 
-it('allows form submission with "inline" secret', async () => {
-  const server = REGISTRY_SERVER
-  server.env_vars = ENV_VARS_OPTIONAL
+const mockUseRunFromRegistry = vi.mocked(useRunFromRegistry)
 
-  const onSubmit = vi.fn()
-  const onOpenChange = vi.fn()
+beforeEach(() => {
+  vi.clearAllMocks()
 
-  render(
-    <QueryClientProvider client={queryClient}>
-      <FormRunFromRegistry
-        isOpen={true}
-        onOpenChange={onOpenChange}
-        server={server}
-        onSubmit={onSubmit}
-      />
-    </QueryClientProvider>
-  )
-
-  await waitFor(() => {
-    expect(screen.getByRole('dialog')).toBeVisible()
-    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
+  // Default mock implementation
+  mockUseRunFromRegistry.mockReturnValue({
+    installServerMutation: vi.fn(),
+    checkServerStatus: vi.fn(),
+    isErrorSecrets: false,
+    isPendingSecrets: false,
   })
-
-  await userEvent.type(
-    screen.getByLabelText('Server name', { selector: 'input' }),
-    'my-awesome-server',
-    {
-      initialSelectionStart: 0,
-      initialSelectionEnd: REGISTRY_SERVER.name?.length,
-    }
-  )
-
-  await userEvent.type(
-    screen.getByLabelText('Secrets', { selector: 'input' }),
-    'my-awesome-secret'
-  )
-  await userEvent.type(
-    screen.getByLabelText('Environment variables', { selector: 'input' }),
-    'my-awesome-env-var'
-  )
-
-  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
-
-  await waitFor(() => {
-    expect(onSubmit).toHaveBeenCalledWith({
-      envVars: [
-        {
-          name: 'ENV_VAR',
-          value: 'my-awesome-env-var',
-        },
-      ],
-      secrets: [
-        {
-          name: 'SECRET',
-          value: {
-            isFromStore: false,
-            secret: 'my-awesome-secret',
-          },
-        },
-      ],
-      serverName: 'my-awesome-server',
-    })
-  })
-  expect(onOpenChange).toHaveBeenCalledWith(false)
 })
 
-it('allows form submission with secret from store', async () => {
-  const mockServer = REGISTRY_SERVER
-  mockServer.env_vars = ENV_VARS_OPTIONAL
+describe('FormRunFromRegistry', () => {
+  it('renders form fields correctly', async () => {
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
 
-  const onSubmit = vi.fn()
-  const onOpenChange = vi.fn()
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
 
-  server.use(
-    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
-      return HttpResponse.json({
-        keys: [
-          {
-            key: 'MY_AWESOME_SECRET',
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
+    expect(screen.getByLabelText('Server Name')).toBeInTheDocument()
+    expect(screen.getByLabelText('Command arguments')).toBeInTheDocument()
+    expect(screen.getByLabelText('SECRET value')).toBeInTheDocument()
+    expect(screen.getByLabelText('ENV_VAR value')).toBeInTheDocument()
+    expect(
+      screen.getByRole('button', { name: 'Install Server' })
+    ).toBeInTheDocument()
+  })
+
+  it('calls installServerMutation when form is submitted with valid data', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
+    const mockOnOpenChange = vi.fn()
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={mockOnOpenChange}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill in the form
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
+
+    await userEvent.type(
+      screen.getByLabelText('SECRET value'),
+      'my-awesome-secret'
+    )
+
+    await userEvent.type(
+      screen.getByLabelText('ENV_VAR value'),
+      'my-awesome-env-var'
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
+        {
+          server,
+          data: {
+            serverName: 'my-awesome-server',
+            envVars: [
+              {
+                name: 'ENV_VAR',
+                value: 'my-awesome-env-var',
+              },
+            ],
+            secrets: [
+              {
+                name: 'SECRET',
+                value: {
+                  isFromStore: false,
+                  secret: 'my-awesome-secret',
+                },
+              },
+            ],
+            cmd_arguments: undefined,
           },
-        ],
+        },
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+          onSettled: expect.any(Function),
+          onError: expect.any(Function),
+        })
+      )
+    })
+  })
+
+  it('handles form submission with secret from store', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    server.use(
+      http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
+        return HttpResponse.json({
+          keys: [
+            {
+              key: 'MY_AWESOME_SECRET',
+            },
+          ],
+        })
       })
+    )
+
+    const mockServer = { ...REGISTRY_SERVER }
+    mockServer.env_vars = ENV_VARS_OPTIONAL
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={mockServer}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
     })
-  )
 
-  render(
-    <QueryClientProvider client={queryClient}>
-      <FormRunFromRegistry
-        isOpen={true}
-        onOpenChange={onOpenChange}
-        server={mockServer}
-        onSubmit={onSubmit}
-      />
-    </QueryClientProvider>
-  )
+    // Fill in server name
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
 
-  await waitFor(() => {
-    expect(screen.getByRole('dialog')).toBeVisible()
-    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
-  })
+    // Select secret from store
+    await userEvent.click(screen.getByLabelText('Use a secret from the store'))
+    await waitFor(() => {
+      expect(
+        screen.getByRole('dialog', { name: 'Secrets store' })
+      ).toBeVisible()
+    })
+    await userEvent.click(
+      screen.getByRole('option', { name: 'MY_AWESOME_SECRET' })
+    )
 
-  await userEvent.type(
-    screen.getByLabelText('Server name', { selector: 'input' }),
-    'my-awesome-server',
-    {
-      initialSelectionStart: 0,
-      initialSelectionEnd: REGISTRY_SERVER.name?.length,
-    }
-  )
+    // Fill in environment variable
+    await userEvent.type(
+      screen.getByLabelText('ENV_VAR value'),
+      'my-awesome-env-var'
+    )
 
-  await userEvent.click(screen.getByLabelText('Use a secret from the store'))
-  await waitFor(() => {
-    expect(screen.getByRole('dialog', { name: 'Secrets store' })).toBeVisible()
-  })
-  await userEvent.click(
-    screen.getByRole('option', { name: 'MY_AWESOME_SECRET' })
-  )
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
 
-  await userEvent.type(
-    screen.getByLabelText('Environment variables', { selector: 'input' }),
-    'my-awesome-env-var'
-  )
-
-  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
-
-  await waitFor(() => {
-    expect(onSubmit).toHaveBeenCalledWith({
-      envVars: [
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
         {
-          name: 'ENV_VAR',
-          value: 'my-awesome-env-var',
-        },
-      ],
-      secrets: [
-        {
-          name: 'SECRET',
-          value: {
-            isFromStore: true,
-            secret: 'MY_AWESOME_SECRET',
+          server: mockServer,
+          data: {
+            serverName: 'my-awesome-server',
+            envVars: [
+              {
+                name: 'ENV_VAR',
+                value: 'my-awesome-env-var',
+              },
+            ],
+            secrets: [
+              {
+                name: 'SECRET',
+                value: {
+                  isFromStore: true,
+                  secret: 'MY_AWESOME_SECRET',
+                },
+              },
+            ],
+            cmd_arguments: undefined,
           },
         },
-      ],
-      serverName: 'my-awesome-server',
+        expect.any(Object)
+      )
     })
   })
-  expect(onOpenChange).toHaveBeenCalledWith(false)
-})
 
-it('allows form submission without optional vars', async () => {
-  const server = REGISTRY_SERVER
-  server.env_vars = ENV_VARS_OPTIONAL
+  it('submits form with empty optional fields', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
 
-  const onSubmit = vi.fn()
-  const onOpenChange = vi.fn()
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
 
-  render(
-    <QueryClientProvider client={queryClient}>
-      <FormRunFromRegistry
-        isOpen={true}
-        onOpenChange={onOpenChange}
-        server={server}
-        onSubmit={onSubmit}
-      />
-    </QueryClientProvider>
-  )
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
 
-  await waitFor(() => {
-    expect(screen.getByRole('dialog')).toBeVisible()
-    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
-  })
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
 
-  await userEvent.type(
-    screen.getByLabelText('Server name', { selector: 'input' }),
-    'my-awesome-server',
-    {
-      initialSelectionStart: 0,
-      initialSelectionEnd: REGISTRY_SERVER.name?.length,
-    }
-  )
+    // Only fill in server name
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
 
-  await waitFor(() => {
-    expect(onSubmit).toHaveBeenCalledWith({
-      // NOTE: This looks broken, but is the desired behavior, these are
-      // filtered in the `useRunFromRegistry` hook
-      envVars: [
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
         {
-          name: 'ENV_VAR',
-          value: '',
-        },
-      ],
-      secrets: [
-        {
-          name: 'SECRET',
-          value: {
-            isFromStore: false,
-            secret: '',
+          server,
+          data: {
+            serverName: 'my-awesome-server',
+            envVars: [
+              {
+                name: 'ENV_VAR',
+                value: '',
+              },
+            ],
+            secrets: [
+              {
+                name: 'SECRET',
+                value: {
+                  isFromStore: false,
+                  secret: '',
+                },
+              },
+            ],
+            cmd_arguments: undefined,
           },
         },
-      ],
-      serverName: 'my-awesome-server',
+        expect.any(Object)
+      )
     })
   })
-  expect(onOpenChange).toHaveBeenCalledWith(false)
-})
 
-it('allows form submission with populated required vars', async () => {
-  const server = REGISTRY_SERVER
-  server.env_vars = ENV_VARS_REQUIRED
-
-  const onSubmit = vi.fn()
-  const onOpenChange = vi.fn()
-
-  render(
-    <QueryClientProvider client={queryClient}>
-      <FormRunFromRegistry
-        isOpen={true}
-        onOpenChange={onOpenChange}
-        server={server}
-        onSubmit={onSubmit}
-      />
-    </QueryClientProvider>
-  )
-
-  await waitFor(() => {
-    expect(screen.getByRole('dialog')).toBeVisible()
-    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
-  })
-
-  await userEvent.type(
-    screen.getByLabelText('Server name', { selector: 'input' }),
-    'my-awesome-server',
-    {
-      initialSelectionStart: 0,
-      initialSelectionEnd: REGISTRY_SERVER.name?.length,
-    }
-  )
-
-  await userEvent.type(
-    screen.getByLabelText('Secrets', { selector: 'input' }),
-    'my-awesome-secret'
-  )
-  await userEvent.type(
-    screen.getByLabelText('Environment variables', { selector: 'input' }),
-    'my-awesome-env-var'
-  )
-
-  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
-
-  await waitFor(() => {
-    expect(onSubmit).toHaveBeenCalledWith({
-      envVars: [
-        {
-          name: 'ENV_VAR',
-          value: 'my-awesome-env-var',
-        },
-      ],
-      secrets: [
-        {
-          name: 'SECRET',
-          value: {
-            isFromStore: false,
-            secret: 'my-awesome-secret',
-          },
-        },
-      ],
-      serverName: 'my-awesome-server',
+  it('validates required fields and shows errors', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
     })
+
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_REQUIRED
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Only fill in server name, leave required fields empty
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).not.toHaveBeenCalled()
+    })
+
+    // Check that validation errors are shown
+    await waitFor(() => {
+      expect(screen.getByLabelText('SECRET value')).toHaveAttribute(
+        'aria-invalid',
+        'true'
+      )
+    })
+
+    expect(screen.getByLabelText('ENV_VAR value')).toHaveAttribute(
+      'aria-invalid',
+      'true'
+    )
   })
-  expect(onOpenChange).toHaveBeenCalledWith(false)
-})
 
-it('renders validation errors when required variables missing', async () => {
-  const server = REGISTRY_SERVER
-  server.env_vars = ENV_VARS_REQUIRED
+  it('shows loading state when submitting', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
 
-  const onSubmit = vi.fn()
-  const onOpenChange = vi.fn()
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
 
-  render(
-    <QueryClientProvider client={queryClient}>
-      <FormRunFromRegistry
-        isOpen={true}
-        onOpenChange={onOpenChange}
-        server={server}
-        onSubmit={onSubmit}
-      />
-    </QueryClientProvider>
-  )
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
 
-  await waitFor(() => {
-    expect(screen.getByRole('dialog')).toBeVisible()
-    expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
-  })
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
 
-  await userEvent.type(
-    screen.getByLabelText('Server name', { selector: 'input' }),
-    'my-awesome-server',
-    {
-      initialSelectionStart: 0,
-      initialSelectionEnd: REGISTRY_SERVER.name?.length,
-    }
-  )
+    // Fill in server name
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
+    // Click submit to trigger loading state
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
 
-  await waitFor(() => {
-    expect(onSubmit).not.toHaveBeenCalled()
-  })
-
-  await waitFor(() => {
+    // The loading state should be shown
+    await waitFor(() => {
+      expect(screen.getByText('Installing server...')).toBeInTheDocument()
+    })
     expect(
-      screen.getByLabelText('Secrets', { selector: 'input' })
-    ).toHaveAttribute('aria-invalid', 'true')
+      screen.getByText(
+        'We are pulling the server image from the registry and installing it.'
+      )
+    ).toBeInTheDocument()
+  })
 
+  it('shows secrets loading state when isPendingSecrets is true', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: true,
+    })
+
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill in server name
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
+
+    // Click submit to trigger loading state
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
+
+    // The loading state should be shown
+    await waitFor(() => {
+      expect(screen.getByText('Installing server...')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error state when isErrorSecrets is true', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: true,
+      isPendingSecrets: false,
+    })
+
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill in server name
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
+
+    // Click submit to trigger the mutation
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
+
+    // Wait for the mutation to be called
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalled()
+    })
+
+    // Simulate the error callback and the settled callback to reset isSubmitting
+    const onErrorCallback =
+      mockInstallServerMutation.mock.calls[0]?.[1]?.onError
+    const onSettledCallback =
+      mockInstallServerMutation.mock.calls[0]?.[1]?.onSettled
+
+    await act(async () => {
+      onErrorCallback?.(new Error('Something went wrong'))
+      onSettledCallback?.(undefined, new Error('Something went wrong'))
+    })
+
+    // The error state should be shown
+    await waitFor(() => {
+      expect(screen.getByText('Error')).toBeInTheDocument()
+    })
     expect(
-      screen.getByLabelText('Environment variables', { selector: 'input' })
-    ).toHaveAttribute('aria-invalid', 'true')
+      screen.getByText(/We were unable to create the secrets for the server/)
+    ).toBeInTheDocument()
+  })
+
+  it('closes dialog on successful submission', async () => {
+    const mockInstallServerMutation = vi.fn()
+    const mockCheckServerStatus = vi.fn()
+    const mockOnOpenChange = vi.fn()
+
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: mockCheckServerStatus,
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={mockOnOpenChange}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill in server name
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
+
+    // Click submit
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalled()
+    })
+
+    // Simulate successful submission
+    const onSuccessCallback =
+      mockInstallServerMutation.mock.calls[0]?.[1]?.onSuccess
+    onSuccessCallback?.()
+
+    await waitFor(() => {
+      expect(mockCheckServerStatus).toHaveBeenCalled()
+    })
+    expect(mockOnOpenChange).toHaveBeenCalledWith(false)
+  })
+
+  it('includes command arguments in form data', async () => {
+    const mockInstallServerMutation = vi.fn()
+    mockUseRunFromRegistry.mockReturnValue({
+      installServerMutation: mockInstallServerMutation,
+      checkServerStatus: vi.fn(),
+      isErrorSecrets: false,
+      isPendingSecrets: false,
+    })
+
+    const server = { ...REGISTRY_SERVER }
+    server.env_vars = ENV_VARS_OPTIONAL
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <FormRunFromRegistry
+          isOpen={true}
+          onOpenChange={vi.fn()}
+          server={server}
+        />
+      </QueryClientProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByRole('dialog')).toBeVisible()
+    })
+
+    // Fill in form fields
+    await userEvent.type(
+      screen.getByLabelText('Server Name'),
+      'my-awesome-server',
+      {
+        initialSelectionStart: 0,
+        initialSelectionEnd: REGISTRY_SERVER.name?.length,
+      }
+    )
+
+    await userEvent.type(
+      screen.getByLabelText('Command arguments'),
+      '--debug --verbose'
+    )
+
+    await userEvent.click(
+      screen.getByRole('button', { name: 'Install Server' })
+    )
+
+    await waitFor(() => {
+      expect(mockInstallServerMutation).toHaveBeenCalledWith(
+        {
+          server,
+          data: expect.objectContaining({
+            cmd_arguments: '--debug --verbose',
+          }),
+        },
+        expect.any(Object)
+      )
+    })
   })
 })

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -115,12 +115,12 @@ describe('FormRunFromRegistry', () => {
       expect(screen.getByRole('dialog')).toBeVisible()
     })
     expect(screen.getByText(`Configure ${REGISTRY_SERVER.name}`)).toBeVisible()
-    expect(screen.getByLabelText('Server Name')).toBeInTheDocument()
+    expect(screen.getByLabelText('Server name')).toBeInTheDocument()
     expect(screen.getByLabelText('Command arguments')).toBeInTheDocument()
     expect(screen.getByLabelText('SECRET value')).toBeInTheDocument()
     expect(screen.getByLabelText('ENV_VAR value')).toBeInTheDocument()
     expect(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     ).toBeInTheDocument()
   })
 
@@ -153,7 +153,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in the form
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -172,7 +172,7 @@ describe('FormRunFromRegistry', () => {
     )
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     await waitFor(() => {
@@ -248,7 +248,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in server name
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -274,7 +274,7 @@ describe('FormRunFromRegistry', () => {
     )
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     await waitFor(() => {
@@ -334,7 +334,7 @@ describe('FormRunFromRegistry', () => {
 
     // Only fill in server name
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -343,7 +343,7 @@ describe('FormRunFromRegistry', () => {
     )
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     await waitFor(() => {
@@ -403,7 +403,7 @@ describe('FormRunFromRegistry', () => {
 
     // Only fill in server name, leave required fields empty
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -412,7 +412,7 @@ describe('FormRunFromRegistry', () => {
     )
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     await waitFor(() => {
@@ -461,7 +461,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in server name
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -471,7 +471,7 @@ describe('FormRunFromRegistry', () => {
 
     // Click submit to trigger loading state
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     // The loading state should be shown
@@ -513,7 +513,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in server name
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -523,7 +523,7 @@ describe('FormRunFromRegistry', () => {
 
     // Click submit to trigger loading state
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     // The loading state should be shown
@@ -560,7 +560,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in server name
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -570,7 +570,7 @@ describe('FormRunFromRegistry', () => {
 
     // Click submit to trigger the mutation
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     // Wait for the mutation to be called
@@ -629,7 +629,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in server name
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -639,7 +639,7 @@ describe('FormRunFromRegistry', () => {
 
     // Click submit
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     await waitFor(() => {
@@ -685,7 +685,7 @@ describe('FormRunFromRegistry', () => {
 
     // Fill in form fields
     await userEvent.type(
-      screen.getByLabelText('Server Name'),
+      screen.getByLabelText('Server name'),
       'my-awesome-server',
       {
         initialSelectionStart: 0,
@@ -699,7 +699,7 @@ describe('FormRunFromRegistry', () => {
     )
 
     await userEvent.click(
-      screen.getByRole('button', { name: 'Install Server' })
+      screen.getByRole('button', { name: 'Install server' })
     )
 
     await waitFor(() => {

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -528,7 +528,7 @@ describe('FormRunFromRegistry', () => {
 
     // The loading state should be shown
     await waitFor(() => {
-      expect(screen.getByText('Installing server...')).toBeInTheDocument()
+      expect(screen.getByText('Creating Secrets...')).toBeInTheDocument()
     })
   })
 
@@ -591,7 +591,7 @@ describe('FormRunFromRegistry', () => {
 
     // The error state should be shown
     await waitFor(() => {
-      expect(screen.getByText('Error')).toBeInTheDocument()
+      expect(screen.getByText('Something went wrong')).toBeInTheDocument()
     })
     expect(
       screen.getByText(/We were unable to create the secrets for the server/)

--- a/renderer/src/features/registry-servers/components/alert-error-form-submission.tsx
+++ b/renderer/src/features/registry-servers/components/alert-error-form-submission.tsx
@@ -1,0 +1,69 @@
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+} from '@/common/components/ui/alert'
+import { Button } from '@/common/components/ui/button'
+import { Separator } from '@/common/components/ui/separator'
+import { X } from 'lucide-react'
+
+interface AlertErrorFormSubmissionProps {
+  error: string
+  isErrorSecrets: boolean
+  onDismiss: () => void
+}
+
+function getErrorTitle(error: string): string {
+  if (error.includes('Failed to retrieve MCP server image')) {
+    return 'We were unable to download the server image'
+  }
+  return 'Something went wrong'
+}
+
+export function AlertErrorFormSubmission({
+  error,
+  isErrorSecrets,
+  onDismiss,
+}: AlertErrorFormSubmissionProps) {
+  const errorTitle = getErrorTitle(error)
+
+  return (
+    <Alert variant="destructive">
+      <AlertTitle className="flex items-center justify-between">
+        {errorTitle}
+        <Button
+          variant="ghost"
+          className="cursor-pointer"
+          size="xs"
+          onClick={onDismiss}
+        >
+          <X />
+        </Button>
+      </AlertTitle>
+      <AlertDescription>
+        <p className="text-red-300">
+          {isErrorSecrets &&
+            'We were unable to create the secrets for the server. '}
+          Check the configuration and try to install again. <br />
+          If you continue to have issues, reach out to our team for help via{' '}
+          <Button asChild variant="link" size="xs" className="text-sm">
+            <a
+              href="https://discord.gg/stacklok"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="pl-0 text-red-300"
+            >
+              Discord.
+            </a>
+          </Button>
+        </p>
+        {!isErrorSecrets && (
+          <>
+            <Separator className="my-2" />
+            <p className="font-mono text-xs text-gray-300">{error}</p>
+          </>
+        )}
+      </AlertDescription>
+    </Alert>
+  )
+}

--- a/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
@@ -28,7 +28,7 @@ import type {
   RegistryImageMetadata,
 } from '@/common/api/generated/types.gen'
 import { zodV4Resolver } from '@/common/lib/zod-v4-resolver'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import { Label } from '@/common/components/ui/label'
 import { cn } from '@/common/lib/utils'
 import { AsteriskIcon } from 'lucide-react'
@@ -40,6 +40,9 @@ import {
 import { FormComboboxSecretStore } from '@/common/components/secrets/form-combobox-secrets-store'
 import { useQuery } from '@tanstack/react-query'
 import { getApiV1BetaWorkloadsOptions } from '@/common/api/generated/@tanstack/react-query.gen'
+import { useRunFromRegistry } from '../hooks/use-run-from-registry'
+import { LoadingStateAlert } from './loading-state-alert'
+import { AlertErrorFormSubmission } from './alert-error-form-submission'
 
 /**
  * Renders an asterisk icon & tooltip for required fields.
@@ -203,19 +206,42 @@ interface FormRunFromRegistryProps {
   server: RegistryImageMetadata | null
   isOpen: boolean
   onOpenChange: (open: boolean) => void
-  onSubmit: (data: FormSchemaRunFromRegistry) => void
 }
 
 export function FormRunFromRegistry({
   server,
   isOpen,
   onOpenChange,
-  onSubmit,
 }: FormRunFromRegistryProps) {
+  const [error, setError] = useState<string | null>(null)
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [loadingSecrets, setLoadingSecrets] = useState<{
+    text: string
+    completedCount: number
+    secretsCount: number
+  } | null>(null)
   const groupedEnvVars = useMemo(
     () => groupEnvVars(server?.env_vars || []),
     [server?.env_vars]
   )
+  const {
+    installServerMutation,
+    checkServerStatus,
+    isErrorSecrets,
+    isPendingSecrets,
+  } = useRunFromRegistry({
+    onSecretSuccess: (completedCount, secretsCount) => {
+      setLoadingSecrets((prev) => ({
+        ...prev,
+        text: `Encrypting secrets (${completedCount} of ${secretsCount})...`,
+        completedCount,
+        secretsCount,
+      }))
+    },
+    onSecretError: (error, variables) => {
+      console.debug('👉 onSecretError', error, variables)
+    },
+  })
 
   const { data } = useQuery({
     ...getApiV1BetaWorkloadsOptions({ query: { all: true } }),
@@ -246,10 +272,32 @@ export function FormRunFromRegistry({
     },
   })
 
-  const onValidate = (data: FormSchemaRunFromRegistry) => {
-    onSubmit(data)
-    onOpenChange(false)
-    form.reset()
+  const onSubmitForm = (data: FormSchemaRunFromRegistry) => {
+    if (!server) return
+
+    setIsSubmitting(true)
+    if (error) {
+      setError(null)
+    }
+
+    installServerMutation(
+      { server, data },
+      {
+        onSuccess: () => {
+          checkServerStatus(data)
+          onOpenChange(false)
+        },
+        onSettled: (_, error) => {
+          setIsSubmitting(false)
+          if (!error) {
+            form.reset()
+          }
+        },
+        onError: (error) => {
+          setError(typeof error === 'string' ? error : error.message)
+        },
+      }
+    )
   }
 
   if (!server) return null
@@ -265,7 +313,7 @@ export function FormRunFromRegistry({
       >
         <Form {...form} key={server?.name}>
           <form
-            onSubmit={form.handleSubmit(onValidate)}
+            onSubmit={form.handleSubmit(onSubmitForm)}
             className="mx-auto flex h-full w-full max-w-3xl flex-col"
           >
             <DialogHeader className="mb-4 p-6">
@@ -275,104 +323,121 @@ export function FormRunFromRegistry({
                 installation.
               </DialogDescription>
             </DialogHeader>
-
-            <div className="relative max-h-[65dvh] space-y-4 overflow-y-auto px-6">
-              <FormField
-                control={form.control}
-                name="serverName"
-                render={({ field }) => (
-                  <FormItem className="mb-10">
-                    <FormLabel>Server name</FormLabel>
-                    <FormDescription>
-                      Choose a unique name for this server instance
-                    </FormDescription>
-                    <FormControl>
-                      <Input
-                        {...field}
-                        placeholder="e.g. my-custom-server"
-                        autoFocus
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
+            {isSubmitting && (
+              <LoadingStateAlert
+                isPendingSecrets={isPendingSecrets}
+                loadingSecrets={loadingSecrets}
               />
-
-              <FormField
-                control={form.control}
-                name="cmd_arguments"
-                render={({ field }) => (
-                  <FormItem className="mb-10">
-                    <FormLabel>Command arguments</FormLabel>
-                    <FormDescription>
-                      Space separated arguments for the command.
-                    </FormDescription>
-                    <FormControl>
-                      <Input
-                        placeholder="e.g. -y --oauth-setup"
-                        defaultValue={field.value}
-                        onChange={(e) => field.onChange(e.target.value)}
-                        name={field.name}
-                      />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
+            )}
+            {!isSubmitting && (
+              <div className="relative max-h-[65dvh] space-y-4 overflow-y-auto px-6">
+                {error && (
+                  <AlertErrorFormSubmission
+                    error={error}
+                    isErrorSecrets={isErrorSecrets}
+                    onDismiss={() => setError(null)}
+                  />
                 )}
-              />
+                <FormField
+                  control={form.control}
+                  name="serverName"
+                  render={({ field }) => (
+                    <FormItem className="mb-10">
+                      <FormLabel>Server Name</FormLabel>
+                      <FormDescription>
+                        Choose a unique name for this server instance
+                      </FormDescription>
+                      <FormControl>
+                        <Input
+                          {...field}
+                          placeholder="e.g. my-custom-server"
+                          autoFocus
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-              {groupedEnvVars.secrets[0] ? (
-                <section className="mb-10">
-                  <Label className="mb-2" htmlFor="secrets.0.value">
-                    Secrets
-                  </Label>
+                <FormField
+                  control={form.control}
+                  name="cmd_arguments"
+                  render={({ field }) => (
+                    <FormItem className="mb-10">
+                      <FormLabel>Command arguments</FormLabel>
+                      <FormDescription>
+                        Space separated arguments for the command.
+                      </FormDescription>
+                      <FormControl>
+                        <Input
+                          placeholder="e.g. -y --oauth-setup"
+                          defaultValue={field.value}
+                          onChange={(e) => field.onChange(e.target.value)}
+                          name={field.name}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
 
-                  <p className="text-muted-foreground mb-6 text-sm">
-                    All secrets are encrypted and securely stored by ToolHive.
-                  </p>
+                {groupedEnvVars.secrets[0] ? (
+                  <section className="mb-10">
+                    <Label className="mb-2" htmlFor="secrets.0.value">
+                      Secrets
+                    </Label>
 
-                  {groupedEnvVars.secrets.map((secret, index) => (
-                    <SecretRow
-                      form={form}
-                      secret={secret}
-                      index={index}
-                      key={secret.name}
-                    />
-                  ))}
-                </section>
-              ) : null}
+                    <p className="text-muted-foreground mb-6 text-sm">
+                      All secrets are encrypted and securely stored by ToolHive.
+                    </p>
 
-              {groupedEnvVars.envVars[0] ? (
-                <section className="mb-10">
-                  <Label className="mb-2" htmlFor="envVars.0.value">
-                    Environment variables
-                  </Label>
+                    {groupedEnvVars.secrets.map((secret, index) => (
+                      <SecretRow
+                        form={form}
+                        secret={secret}
+                        index={index}
+                        key={secret.name}
+                      />
+                    ))}
+                  </section>
+                ) : null}
 
-                  <p className="text-muted-foreground mb-6 text-sm">
-                    Environment variables are used to pass configuration
-                    settings to the server.
-                  </p>
+                {groupedEnvVars.envVars[0] ? (
+                  <section className="mb-10">
+                    <Label className="mb-2" htmlFor="envVars.0.value">
+                      Environment variables
+                    </Label>
 
-                  {groupedEnvVars.envVars.map((envVar, index) => (
-                    <EnvVarRow
-                      form={form}
-                      envVar={envVar}
-                      index={index}
-                      key={envVar.name}
-                    />
-                  ))}
-                </section>
-              ) : null}
-            </div>
+                    <p className="text-muted-foreground mb-6 text-sm">
+                      Environment variables are used to pass configuration
+                      settings to the server.
+                    </p>
+
+                    {groupedEnvVars.envVars.map((envVar, index) => (
+                      <EnvVarRow
+                        form={form}
+                        envVar={envVar}
+                        index={index}
+                        key={envVar.name}
+                      />
+                    ))}
+                  </section>
+                ) : null}
+              </div>
+            )}
 
             <DialogFooter className="p-6">
               <Button
                 type="button"
                 variant="outline"
+                disabled={isSubmitting}
                 onClick={() => onOpenChange(false)}
               >
                 Cancel
               </Button>
-              <Button type="submit">Install server</Button>
+              <Button disabled={isSubmitting} type="submit">
+                Install Server
+              </Button>
             </DialogFooter>
           </form>
         </Form>

--- a/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
@@ -343,7 +343,7 @@ export function FormRunFromRegistry({
                   name="serverName"
                   render={({ field }) => (
                     <FormItem className="mb-10">
-                      <FormLabel>Server Name</FormLabel>
+                      <FormLabel>Server name</FormLabel>
                       <FormDescription>
                         Choose a unique name for this server instance
                       </FormDescription>
@@ -436,7 +436,7 @@ export function FormRunFromRegistry({
                 Cancel
               </Button>
               <Button disabled={isSubmitting} type="submit">
-                Install Server
+                Install server
               </Button>
             </DialogFooter>
           </form>

--- a/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
@@ -4,19 +4,11 @@ import { FormRunFromRegistry } from './form-run-from-registry'
 import { useState } from 'react'
 import { useFilterSort } from '@/common/hooks/use-filter-sort'
 import { InputSearch } from '@/common/components/ui/input-search'
-import type {
-  InstallServerCheck,
-  InstallServerMutation,
-} from '../hooks/use-run-from-registry'
 
 export function GridCardsRegistryServer({
   servers,
-  onSubmit,
-  checkServerStatus,
 }: {
   servers: RegistryImageMetadata[]
-  onSubmit: InstallServerMutation
-  checkServerStatus: InstallServerCheck
 }) {
   const [selectedServer, setSelectedServer] =
     useState<RegistryImageMetadata | null>(null)
@@ -65,8 +57,6 @@ export function GridCardsRegistryServer({
         server={selectedServer}
         isOpen={isModalOpen}
         onOpenChange={setIsModalOpen}
-        onSubmit={onSubmit}
-        checkServerStatus={checkServerStatus}
       />
     </div>
   )

--- a/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
@@ -2,19 +2,21 @@ import type { RegistryImageMetadata } from '@/common/api/generated/types.gen'
 import { CardRegistryServer } from './card-registry-server'
 import { FormRunFromRegistry } from './form-run-from-registry'
 import { useState } from 'react'
-import type { FormSchemaRunFromRegistry } from '../lib/get-form-schema-run-from-registry'
 import { useFilterSort } from '@/common/hooks/use-filter-sort'
 import { InputSearch } from '@/common/components/ui/input-search'
+import type {
+  InstallServerCheck,
+  InstallServerMutation,
+} from '../hooks/use-run-from-registry'
 
 export function GridCardsRegistryServer({
   servers,
   onSubmit,
+  checkServerStatus,
 }: {
   servers: RegistryImageMetadata[]
-  onSubmit?: (
-    server: RegistryImageMetadata,
-    data: FormSchemaRunFromRegistry
-  ) => void
+  onSubmit: InstallServerMutation
+  checkServerStatus: InstallServerCheck
 }) {
   const [selectedServer, setSelectedServer] =
     useState<RegistryImageMetadata | null>(null)
@@ -32,12 +34,6 @@ export function GridCardsRegistryServer({
   const handleCardClick = (server: RegistryImageMetadata) => {
     setSelectedServer(server)
     setIsModalOpen(true)
-  }
-
-  const handleModalSubmit = (data: FormSchemaRunFromRegistry) => {
-    if (selectedServer && onSubmit) {
-      onSubmit(selectedServer, data)
-    }
   }
 
   return (
@@ -69,7 +65,8 @@ export function GridCardsRegistryServer({
         server={selectedServer}
         isOpen={isModalOpen}
         onOpenChange={setIsModalOpen}
-        onSubmit={handleModalSubmit}
+        onSubmit={onSubmit}
+        checkServerStatus={checkServerStatus}
       />
     </div>
   )

--- a/renderer/src/features/registry-servers/components/loading-state-alert.tsx
+++ b/renderer/src/features/registry-servers/components/loading-state-alert.tsx
@@ -1,0 +1,47 @@
+import {
+  Alert,
+  AlertTitle,
+  AlertDescription,
+} from '@/common/components/ui/alert'
+import { Progress } from '@/common/components/ui/progress'
+import { Loader } from 'lucide-react'
+
+interface LoadingStateAlertProps {
+  isPendingSecrets: boolean
+  loadingSecrets?: {
+    text: string
+    completedCount: number
+    secretsCount: number
+  } | null
+}
+
+export function LoadingStateAlert({
+  isPendingSecrets,
+  loadingSecrets,
+}: LoadingStateAlertProps) {
+  return (
+    <div className="relative space-y-4 px-6">
+      <Alert>
+        <Loader className="size-4 animate-spin" />
+        <AlertTitle>
+          {isPendingSecrets ? 'Creating Secrets...' : 'Installing server...'}
+        </AlertTitle>
+        <AlertDescription>
+          {isPendingSecrets && loadingSecrets
+            ? loadingSecrets?.text
+            : 'We are pulling the server image from the registry and installing it.'}
+          {isPendingSecrets && loadingSecrets && (
+            <Progress
+              value={
+                (loadingSecrets?.completedCount /
+                  loadingSecrets?.secretsCount) *
+                100
+              }
+              className="my-2 w-full"
+            />
+          )}
+        </AlertDescription>
+      </Alert>
+    </div>
+  )
+}

--- a/renderer/src/features/registry-servers/hooks/use-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/hooks/use-run-from-registry.tsx
@@ -5,7 +5,6 @@ import {
   type RegistryImageMetadata,
   type SecretsSecretParameter,
   type V1CreateRequest,
-  type V1CreateWorkloadResponse,
 } from '@/common/api/generated'
 import {
   postApiV1BetaWorkloadsMutation,
@@ -14,11 +13,7 @@ import {
   getApiV1BetaWorkloadsQueryKey,
 } from '@/common/api/generated/@tanstack/react-query.gen'
 import { pollServerStatus } from '@/common/lib/polling'
-import {
-  useMutation,
-  useQueryClient,
-  type UseMutateFunction,
-} from '@tanstack/react-query'
+import { useMutation, useQueryClient } from '@tanstack/react-query'
 import type { FormSchemaRunFromRegistry } from '../lib/get-form-schema-run-from-registry'
 import { useCallback, useRef } from 'react'
 import {
@@ -32,17 +27,7 @@ import { Button } from '@/common/components/ui/button'
 import { prepareSecretsWithoutNamingCollision } from '@/common/lib/secrets/prepare-secrets-without-naming-collision'
 import { Link } from '@tanstack/react-router'
 
-export type InstallServerMutation = UseMutateFunction<
-  V1CreateWorkloadResponse | undefined,
-  Error,
-  {
-    server: RegistryImageMetadata
-    data: FormSchemaRunFromRegistry
-  },
-  unknown
->
-
-export type InstallServerCheck = (
+type InstallServerCheck = (
   data: FormSchemaRunFromRegistry
 ) => Promise<unknown> | unknown
 

--- a/renderer/src/features/registry-servers/hooks/use-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/hooks/use-run-from-registry.tsx
@@ -1,16 +1,51 @@
-import { type RegistryImageMetadata } from '@/common/api/generated'
+import {
+  getApiV1BetaSecretsDefaultKeys,
+  type RegistryImageMetadata,
+  type SecretsSecretParameter,
+  type V1CreateRequest,
+  type V1CreateWorkloadResponse,
+} from '@/common/api/generated'
 import {
   postApiV1BetaWorkloadsMutation,
   getApiV1BetaWorkloadsByNameOptions,
   postApiV1BetaSecretsDefaultKeysMutation,
+  getApiV1BetaWorkloadsQueryKey,
 } from '@/common/api/generated/@tanstack/react-query.gen'
 import { pollServerStatus } from '@/common/lib/polling'
-import { useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  useMutation,
+  useQueryClient,
+  type UseMutateFunction,
+} from '@tanstack/react-query'
 import type { FormSchemaRunFromRegistry } from '../lib/get-form-schema-run-from-registry'
-import { useCallback } from 'react'
-import { orchestrateRunRegistryServer } from '../lib/orchestrate-run-registry-server'
+import { useCallback, useRef } from 'react'
+import {
+  getDefinedSecrets,
+  groupSecrets,
+  prepareCreateWorkloadData,
+  saveSecrets,
+} from '../lib/orchestrate-run-registry-server'
+import { toast } from 'sonner'
+import { Button } from '@/common/components/ui/button'
+import { prepareSecretsWithoutNamingCollision } from '@/common/lib/secrets/prepare-secrets-without-naming-collision'
+import { Link } from '@tanstack/react-router'
+
+export type InstallServerMutation = UseMutateFunction<
+  V1CreateWorkloadResponse | undefined,
+  Error,
+  {
+    server: RegistryImageMetadata
+    data: FormSchemaRunFromRegistry
+  },
+  unknown
+>
+
+export type InstallServerCheck = (
+  data: FormSchemaRunFromRegistry
+) => Promise<unknown> | unknown
 
 export function useRunFromRegistry() {
+  const toastIdRef = useRef(new Date(Date.now()).toISOString())
   const queryClient = useQueryClient()
 
   const { mutateAsync: saveSecret } = useMutation({
@@ -20,35 +55,171 @@ export function useRunFromRegistry() {
     ...postApiV1BetaWorkloadsMutation(),
   })
 
-  const getIsServerReady: (serverName: string) => Promise<boolean> =
-    useCallback(
-      (serverName: string) =>
-        pollServerStatus(
-          () =>
-            queryClient.fetchQuery(
-              getApiV1BetaWorkloadsByNameOptions({
-                path: { name: serverName },
-              })
-            ),
-          'running'
-        ),
-      [queryClient]
-    )
+  const handleSettled = useCallback<InstallServerCheck>(
+    async (formData) => {
+      console.debug('👉 handleSettled')
 
-  const handleSubmit = useCallback(
-    async (server: RegistryImageMetadata, data: FormSchemaRunFromRegistry) =>
-      orchestrateRunRegistryServer({
-        server,
-        data,
-        saveSecret,
-        createWorkload,
-        queryClient,
-        getIsServerReady,
-      }),
-    [createWorkload, getIsServerReady, queryClient, saveSecret]
+      toast.loading(`Starting "${formData.serverName}"...`, {
+        duration: 30_000,
+        id: toastIdRef.current,
+      })
+
+      const isServerReady = await pollServerStatus(
+        () =>
+          queryClient.fetchQuery(
+            getApiV1BetaWorkloadsByNameOptions({
+              path: { name: formData.serverName },
+            })
+          ),
+        'running'
+      )
+
+      if (isServerReady) {
+        await queryClient.invalidateQueries({
+          queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+        })
+
+        toast.success(`"${formData.serverName}" started successfully.`, {
+          id: toastIdRef.current,
+          duration: 5_000, // slightly longer than default
+          action: (
+            <Button asChild>
+              <Link
+                to="/"
+                search={{ newServerName: formData.serverName }}
+                onClick={() => toast.dismiss(toastIdRef.current)}
+                viewTransition={{ types: ['slide-left'] }}
+                className="ml-auto"
+              >
+                View
+              </Link>
+            </Button>
+          ),
+        })
+      } else {
+        toast.warning(
+          `Server "${formData.serverName}" was created but may still be starting up. Check the servers list to monitor its status.`,
+          {
+            id: toastIdRef.current,
+            duration: 2_000, // reset to default
+          }
+        )
+      }
+    },
+    [queryClient]
   )
 
+  const { mutate: installServer } = useMutation({
+    mutationFn: async ({
+      server,
+      data,
+    }: {
+      server: RegistryImageMetadata
+      data: FormSchemaRunFromRegistry
+    }) => {
+      console.debug('👉 server:', server)
+      console.debug('👉 data:', data)
+      let newlyCreatedSecrets: SecretsSecretParameter[] = []
+
+      // NOTE: Due to how we populate the names of the secrets in the form, we may
+      // have secrets with a `key` but no `value`. We filter those out.
+      const definedSecrets = getDefinedSecrets(data.secrets)
+
+      // Step 1: Group secrets into new and existing
+      // We need to know which secrets are new (not from the registry) and which are
+      // existing (already stored). This helps us handle the encryption and storage
+      // of secrets correctly.
+      const { existingSecrets, newSecrets } = groupSecrets(definedSecrets)
+
+      // Step 2: Fetch existing secrets & handle naming collisions
+      // We need an up-to-date list of secrets so we can handle any existing keys
+      // safely & correctly. This is done with a manual fetch call to avoid freshness issues /
+      // side-effects from the `useQuery` hook.
+      // In the event of a naming collision, we will append an incrementing number
+      // to the secret name, e.g. `MY_API_TOKEN` -> `MY_API_TOKEN_2`
+      const { data: fetchedSecrets } = await getApiV1BetaSecretsDefaultKeys({
+        throwOnError: true,
+      }).catch((e) => {
+        toast.error(
+          [
+            `An error occurred while starting the server.`,
+            'Could not retrieve secrets from the secret store.',
+            e instanceof Error ? `\n${e.message}` : null,
+          ].join('\n'),
+          {
+            id: toastIdRef.current,
+          }
+        )
+        throw e
+      })
+      const preparedNewSecrets = prepareSecretsWithoutNamingCollision(
+        newSecrets,
+        fetchedSecrets
+      )
+
+      // Step 3: Encrypt secrets
+      // If there are secrets with values, create them in the secret store first.
+      // We need the data returned by the API to pass along with the "run workload" request.
+      if (preparedNewSecrets.length > 0) {
+        try {
+          newlyCreatedSecrets = await saveSecrets(
+            preparedNewSecrets,
+            saveSecret,
+            toastIdRef.current
+          )
+        } catch (error) {
+          toast.error(
+            [
+              'An error occurred while starting the server.',
+              error instanceof Error ? `\n${error.message}` : null,
+            ].join(''),
+            {
+              id: toastIdRef.current,
+            }
+          )
+          return
+        }
+      }
+
+      // Step 4: Create the MCP server workload
+      // Prepare the request data and send it to the API
+      // We pass the encrypted secrets along with the request.
+      const secretsForRequest: SecretsSecretParameter[] = [
+        ...newlyCreatedSecrets,
+        ...existingSecrets.map((secret) => ({
+          name: secret.value.secret,
+          target: secret.name,
+        })),
+      ]
+
+      const createRequest: V1CreateRequest = prepareCreateWorkloadData(
+        server,
+        data,
+        secretsForRequest
+      )
+
+      const response = await createWorkload({
+        body: createRequest,
+      })
+      return response
+    },
+    onError: (error) => {
+      console.debug('👉 error:', error)
+      toast.error(
+        [
+          'An error occurred while starting the server.',
+          error instanceof Error ? `\n${error.message}` : null,
+        ].join(''),
+        {
+          id: toastIdRef.current,
+        }
+      )
+      return
+    },
+  })
+
   return {
-    handleSubmit,
+    handleSubmit: installServer,
+    checkServerStatus: handleSettled,
   }
 }

--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -336,7 +336,7 @@ describe('saveSecrets', () => {
   })
 
   it('throws error when saveSecret returns no key', async () => {
-    const mockSaveSecret = vi.fn().mockImplementation((body, options) => {
+    const mockSaveSecret = vi.fn().mockImplementation((_, options) => {
       // Call the onSuccess callback to simulate successful save
       options.onSuccess?.()
       return Promise.resolve({ key: null })

--- a/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
+++ b/renderer/src/features/registry-servers/lib/__tests__/orchestrate-run-registry-server.test.tsx
@@ -1,562 +1,386 @@
-import { it, expect, vi } from 'vitest'
-import type { QueryClient } from '@tanstack/react-query'
-
-import { getApiV1BetaWorkloadsQueryKey } from '@/common/api/generated/@tanstack/react-query.gen'
-import { toast } from 'sonner'
-import { server } from '@/common/mocks/node'
-import { http, HttpResponse } from 'msw'
-import { mswEndpoint } from '@/common/mocks/msw-endpoint'
+import { it, expect, vi, describe } from 'vitest'
 import type { FormSchemaRunFromRegistry } from '../get-form-schema-run-from-registry'
-import { orchestrateRunRegistryServer } from '../orchestrate-run-registry-server'
 import type { RegistryImageMetadata } from '@/common/api/generated'
-
-vi.mock('sonner', async () => {
-  const original = await vi.importActual<typeof import('sonner')>('sonner')
-  return {
-    ...original,
-    toast: {
-      loading: vi.fn(),
-      success: vi.fn(),
-      warning: vi.fn(),
-      error: vi.fn(),
-      dismiss: vi.fn(),
-    },
-  }
-})
+import {
+  getDefinedSecrets,
+  saveSecrets,
+  prepareCreateWorkloadData,
+  groupSecrets,
+} from '../orchestrate-run-registry-server'
+import type { DefinedSecret, PreparedSecret } from '@/common/types/secrets'
 
 beforeEach(() => {
   vi.clearAllMocks()
 })
 
-it('submits without any optional fields', async () => {
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
+describe('getDefinedSecrets', () => {
+  it('filters out secrets with empty name or secret value', () => {
+    const secrets: FormSchemaRunFromRegistry['secrets'] = [
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: false },
+      },
+      {
+        name: '',
+        value: { secret: 'some-value', isFromStore: false },
+      },
+      {
+        name: 'EMPTY_SECRET',
+        value: { secret: '', isFromStore: false },
+      },
+      {
+        name: 'VALID_SECRET',
+        value: { secret: 'valid-value', isFromStore: true },
+      },
+    ]
 
+    const result = getDefinedSecrets(secrets)
+
+    expect(result).toEqual([
+      {
+        name: 'GITHUB_API_TOKEN',
+        value: { secret: 'foo-bar', isFromStore: false },
+      },
+      {
+        name: 'VALID_SECRET',
+        value: { secret: 'valid-value', isFromStore: true },
+      },
+    ])
+  })
+
+  it('returns empty array when no valid secrets', () => {
+    const secrets: FormSchemaRunFromRegistry['secrets'] = [
+      {
+        name: '',
+        value: { secret: 'some-value', isFromStore: false },
+      },
+      {
+        name: 'EMPTY_SECRET',
+        value: { secret: '', isFromStore: false },
+      },
+    ]
+
+    const result = getDefinedSecrets(secrets)
+
+    expect(result).toEqual([])
+  })
+
+  it('handles empty secrets array', () => {
+    const result = getDefinedSecrets([])
+    expect(result).toEqual([])
+  })
+})
+
+describe('groupSecrets', () => {
+  it('groups secrets into new and existing categories', () => {
+    const secrets: DefinedSecret[] = [
+      {
+        name: 'NEW_SECRET',
+        value: { secret: 'new-value', isFromStore: false },
+      },
+      {
+        name: 'EXISTING_SECRET',
+        value: { secret: 'existing-key', isFromStore: true },
+      },
+      {
+        name: 'ANOTHER_NEW_SECRET',
+        value: { secret: 'another-new-value', isFromStore: false },
+      },
+    ]
+
+    const result = groupSecrets(secrets)
+
+    expect(result.newSecrets).toEqual([
+      {
+        name: 'NEW_SECRET',
+        value: { secret: 'new-value', isFromStore: false },
+      },
+      {
+        name: 'ANOTHER_NEW_SECRET',
+        value: { secret: 'another-new-value', isFromStore: false },
+      },
+    ])
+
+    expect(result.existingSecrets).toEqual([
+      {
+        name: 'EXISTING_SECRET',
+        value: { secret: 'existing-key', isFromStore: true },
+      },
+    ])
+  })
+
+  it('handles empty secrets array', () => {
+    const result = groupSecrets([])
+    expect(result).toEqual({
+      newSecrets: [],
+      existingSecrets: [],
+    })
+  })
+
+  it('handles all new secrets', () => {
+    const secrets: DefinedSecret[] = [
+      {
+        name: 'NEW_SECRET_1',
+        value: { secret: 'value-1', isFromStore: false },
+      },
+      {
+        name: 'NEW_SECRET_2',
+        value: { secret: 'value-2', isFromStore: false },
+      },
+    ]
+
+    const result = groupSecrets(secrets)
+
+    expect(result.newSecrets).toEqual(secrets)
+    expect(result.existingSecrets).toEqual([])
+  })
+
+  it('handles all existing secrets', () => {
+    const secrets: DefinedSecret[] = [
+      {
+        name: 'EXISTING_SECRET_1',
+        value: { secret: 'key-1', isFromStore: true },
+      },
+      {
+        name: 'EXISTING_SECRET_2',
+        value: { secret: 'key-2', isFromStore: true },
+      },
+    ]
+
+    const result = groupSecrets(secrets)
+
+    expect(result.newSecrets).toEqual([])
+    expect(result.existingSecrets).toEqual(secrets)
+  })
+})
+
+describe('prepareCreateWorkloadData', () => {
   const SERVER: RegistryImageMetadata = {
     name: 'test-server',
     image: 'test-image',
     transport: 'stdio',
+    target_port: 8080,
   }
 
-  const DATA: FormSchemaRunFromRegistry = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [],
-  }
+  it('prepares workload data with all fields', () => {
+    const data: FormSchemaRunFromRegistry = {
+      serverName: 'Test Server',
+      envVars: [
+        { name: 'DEBUG', value: 'true' },
+        { name: 'PORT', value: '8080' },
+      ],
+      secrets: [],
+      cmd_arguments: '--debug --port 8080',
+    }
 
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
-  })
+    const secrets = [
+      {
+        name: 'GITHUB_API_TOKEN',
+        target: 'GITHUB_API_TOKEN',
+      },
+    ]
 
-  expect(mockSaveSecret).toHaveBeenCalledTimes(0)
-  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: {
+    const result = prepareCreateWorkloadData(SERVER, data, secrets)
+
+    expect(result).toEqual({
       name: 'Test Server',
       image: 'test-image',
       transport: 'stdio',
+      env_vars: ['DEBUG=true', 'PORT=8080'],
+      secrets,
+      cmd_arguments: ['--debug', '--port', '8080'],
+      target_port: 8080,
+    })
+  })
+
+  it('handles empty env vars and secrets', () => {
+    const data: FormSchemaRunFromRegistry = {
+      serverName: 'Test Server',
+      envVars: [],
+      secrets: [],
+    }
+
+    const result = prepareCreateWorkloadData(SERVER, data)
+
+    expect(result).toEqual({
+      name: 'Test Server',
+      image: 'test-image',
+      transport: 'stdio',
+      env_vars: [],
       secrets: [],
       cmd_arguments: [],
-      env_vars: [],
-    },
-  })
-  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
-  })
-
-  expect(toast.success).toHaveBeenCalledWith(
-    '"Test Server" started successfully.',
-    expect.any(Object)
-  )
-})
-
-it('handles new secrets properly', async () => {
-  server.use(
-    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
-      return HttpResponse.json({ keys: [] })
+      target_port: 8080,
     })
-  )
-
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [
-      {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: false },
-      },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-  } as const satisfies FormSchemaRunFromRegistry
-
-  mockSaveSecret.mockResolvedValueOnce({ key: DATA.secrets[0].name })
-
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
   })
 
-  expect(mockSaveSecret).toHaveBeenCalledWith(
-    { body: { key: 'GITHUB_API_TOKEN', value: 'foo-bar' } },
-    expect.any(Object)
-  )
+  it('handles empty cmd_arguments', () => {
+    const data: FormSchemaRunFromRegistry = {
+      serverName: 'Test Server',
+      envVars: [],
+      secrets: [],
+      cmd_arguments: '',
+    }
 
-  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: {
-      name: 'Test Server',
+    const result = prepareCreateWorkloadData(SERVER, data)
+
+    expect(result.cmd_arguments).toEqual([])
+  })
+
+  it('handles undefined cmd_arguments', () => {
+    const data: FormSchemaRunFromRegistry = {
+      serverName: 'Test Server',
+      envVars: [],
+      secrets: [],
+      cmd_arguments: undefined,
+    }
+
+    const result = prepareCreateWorkloadData(SERVER, data)
+
+    expect(result.cmd_arguments).toEqual([])
+  })
+
+  it('handles server without target_port', () => {
+    const serverWithoutPort: RegistryImageMetadata = {
+      name: 'test-server',
       image: 'test-image',
       transport: 'stdio',
-      secrets: [
-        {
-          name: 'GITHUB_API_TOKEN',
-          target: 'GITHUB_API_TOKEN',
-        },
-      ],
-      cmd_arguments: [],
-      env_vars: [],
-    },
-  })
-  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
-  })
+    }
 
-  expect(toast.success).toHaveBeenCalledWith(
-    '"Test Server" started successfully.',
-    expect.any(Object)
-  )
+    const data: FormSchemaRunFromRegistry = {
+      serverName: 'Test Server',
+      envVars: [],
+      secrets: [],
+    }
+
+    const result = prepareCreateWorkloadData(serverWithoutPort, data)
+
+    expect(result.target_port).toBeUndefined()
+  })
 })
 
-it('handles existing secrets from the store properly', async () => {
-  server.use(
-    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
-      return HttpResponse.json({ keys: [{ key: 'GITHUB_API_TOKEN' }] })
+describe('saveSecrets', () => {
+  it('saves secrets serially and calls progress callbacks', async () => {
+    const mockSaveSecret = vi.fn().mockImplementation((body, options) => {
+      // Call the onSuccess callback to simulate successful save
+      options.onSuccess?.()
+      return Promise.resolve({ key: body.body.key + '_KEY' })
     })
-  )
 
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
+    const onSecretSuccess = vi.fn()
+    const onSecretError = vi.fn()
 
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [
+    const secrets: PreparedSecret[] = [
       {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'GITHUB_API_TOKEN', isFromStore: true },
+        secretStoreKey: 'SECRET_1',
+        target: 'SECRET_1',
+        value: 'value-1',
       },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-  } as const satisfies FormSchemaRunFromRegistry
+      {
+        secretStoreKey: 'SECRET_2',
+        target: 'SECRET_2',
+        value: 'value-2',
+      },
+    ]
 
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
+    const result = await saveSecrets(
+      secrets,
+      mockSaveSecret,
+      onSecretSuccess,
+      onSecretError
+    )
+
+    expect(mockSaveSecret).toHaveBeenCalledTimes(2)
+    expect(mockSaveSecret).toHaveBeenCalledWith(
+      { body: { key: 'SECRET_1', value: 'value-1' } },
+      expect.any(Object)
+    )
+    expect(mockSaveSecret).toHaveBeenCalledWith(
+      { body: { key: 'SECRET_2', value: 'value-2' } },
+      expect.any(Object)
+    )
+
+    expect(onSecretSuccess).toHaveBeenCalledTimes(2)
+    expect(onSecretSuccess).toHaveBeenCalledWith(1, 2)
+    expect(onSecretSuccess).toHaveBeenCalledWith(2, 2)
+
+    expect(onSecretError).not.toHaveBeenCalled()
+
+    expect(result).toEqual([
+      {
+        name: 'SECRET_1_KEY',
+        target: 'SECRET_1',
+      },
+      {
+        name: 'SECRET_2_KEY',
+        target: 'SECRET_2',
+      },
+    ])
   })
 
-  expect(mockSaveSecret).not.toHaveBeenCalled()
+  it('handles empty secrets array', async () => {
+    const mockSaveSecret = vi.fn()
+    const onSecretSuccess = vi.fn()
+    const onSecretError = vi.fn()
 
-  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: {
-      name: 'Test Server',
-      image: 'test-image',
-      transport: 'stdio',
-      secrets: [
-        {
-          name: 'GITHUB_API_TOKEN',
-          target: 'GITHUB_API_TOKEN',
-        },
-      ],
-      cmd_arguments: [],
-      env_vars: [],
-    },
-  })
-  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
+    const result = await saveSecrets(
+      [],
+      mockSaveSecret,
+      onSecretSuccess,
+      onSecretError
+    )
+
+    expect(mockSaveSecret).not.toHaveBeenCalled()
+    expect(onSecretSuccess).not.toHaveBeenCalled()
+    expect(onSecretError).not.toHaveBeenCalled()
+    expect(result).toEqual([])
   })
 
-  expect(toast.success).toHaveBeenCalledWith(
-    '"Test Server" started successfully.',
-    expect.any(Object)
-  )
-})
-
-it('handles naming collisions with secrets from the store', async () => {
-  server.use(
-    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
-      return HttpResponse.json({ keys: [{ key: 'GITHUB_API_TOKEN' }] })
+  it('throws error when saveSecret returns no key', async () => {
+    const mockSaveSecret = vi.fn().mockImplementation((body, options) => {
+      // Call the onSuccess callback to simulate successful save
+      options.onSuccess?.()
+      return Promise.resolve({ key: null })
     })
-  )
+    const onSecretSuccess = vi.fn()
+    const onSecretError = vi.fn()
 
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [
+    const secrets: PreparedSecret[] = [
       {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: false },
+        secretStoreKey: 'SECRET_1',
+        target: 'SECRET_1',
+        value: 'value-1',
       },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-  } as const satisfies FormSchemaRunFromRegistry
+    ]
 
-  mockSaveSecret.mockResolvedValueOnce({ key: 'GITHUB_API_TOKEN_2' })
-
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
+    await expect(
+      saveSecrets(secrets, mockSaveSecret, onSecretSuccess, onSecretError)
+    ).rejects.toThrow('Failed to create secret for key "SECRET_1"')
   })
 
-  expect(mockSaveSecret).toHaveBeenCalledWith(
-    { body: { key: 'GITHUB_API_TOKEN_2', value: 'foo-bar' } },
-    expect.any(Object)
-  )
-
-  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: {
-      name: 'Test Server',
-      image: 'test-image',
-      transport: 'stdio',
-      secrets: [
-        {
-          name: 'GITHUB_API_TOKEN_2',
-          target: 'GITHUB_API_TOKEN',
-        },
-      ],
-      cmd_arguments: [],
-      env_vars: [],
-    },
-  })
-  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
-  })
-
-  expect(toast.success).toHaveBeenCalledWith(
-    '"Test Server" started successfully.',
-    expect.any(Object)
-  )
-})
-
-it('handles both new and existing secrets', async () => {
-  server.use(
-    http.get(mswEndpoint('/api/v1beta/secrets/default/keys'), () => {
-      return HttpResponse.json({ keys: [{ key: 'ATLASSIAN_API_TOKEN' }] })
+  it('calls error callback when saveSecret fails', async () => {
+    const mockError = new Error('Save failed')
+    const mockSaveSecret = vi.fn().mockImplementation((body, options) => {
+      // Call the onError callback to simulate failed save
+      options.onError?.(mockError, body)
+      return Promise.reject(mockError)
     })
-  )
+    const onSecretSuccess = vi.fn()
+    const onSecretError = vi.fn()
 
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [
+    const secrets: PreparedSecret[] = [
       {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: false },
+        secretStoreKey: 'SECRET_1',
+        target: 'SECRET_1',
+        value: 'value-1',
       },
-      {
-        name: 'ATLASSIAN_API_TOKEN',
-        value: { secret: 'ATLASSIAN_API_TOKEN', isFromStore: true },
-      },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-  } as const satisfies FormSchemaRunFromRegistry
+    ]
 
-  mockSaveSecret.mockResolvedValueOnce({ key: DATA.secrets[0].name })
+    await expect(
+      saveSecrets(secrets, mockSaveSecret, onSecretSuccess, onSecretError)
+    ).rejects.toThrow('Save failed')
 
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
+    expect(onSecretError).toHaveBeenCalledWith(mockError, {
+      body: { key: 'SECRET_1', value: 'value-1' },
+    })
   })
-
-  expect(mockSaveSecret).toHaveBeenCalledWith(
-    { body: { key: 'GITHUB_API_TOKEN', value: 'foo-bar' } },
-    expect.any(Object)
-  )
-
-  expect(mockGetIsServerReady).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledTimes(1)
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: {
-      name: 'Test Server',
-      image: 'test-image',
-      transport: 'stdio',
-      secrets: [
-        {
-          name: 'GITHUB_API_TOKEN',
-          target: 'GITHUB_API_TOKEN',
-        },
-        {
-          name: 'ATLASSIAN_API_TOKEN',
-          target: 'ATLASSIAN_API_TOKEN',
-        },
-      ],
-      cmd_arguments: [],
-      env_vars: [],
-    },
-  })
-  expect(mockQueryClient.invalidateQueries).toHaveBeenCalledWith({
-    queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
-  })
-
-  expect(toast.success).toHaveBeenCalledWith(
-    '"Test Server" started successfully.',
-    expect.any(Object)
-  )
-})
-
-it('handles error when saving a secret fails', async () => {
-  const mockError = new Error('Failed to save secret')
-  const mockSaveSecret = vi.fn().mockRejectedValue(mockError)
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn()
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [
-      {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: false },
-      },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-  } as const satisfies FormSchemaRunFromRegistry
-
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
-  })
-
-  // createWorkload should not be called if saving secrets fails
-  expect(mockCreateWorkload).not.toHaveBeenCalled()
-  expect(mockGetIsServerReady).not.toHaveBeenCalled()
-
-  // Error toast should be shown
-  expect(toast.error).toHaveBeenCalledWith(
-    'An error occurred while starting the server.\nFailed to save secret',
-    expect.any(Object)
-  )
-})
-
-it('handles environment variables properly', async () => {
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [
-      { name: 'DEBUG', value: 'true' },
-      { name: 'PORT', value: '8080' },
-    ],
-    secrets: [
-      {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: true },
-      },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-  } as const satisfies FormSchemaRunFromRegistry
-
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
-  })
-
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: expect.objectContaining({
-      env_vars: ['DEBUG=true', 'PORT=8080'],
-    }),
-  })
-})
-
-it('handles command arguments properly', async () => {
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(true)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA = {
-    serverName: 'Test Server',
-    envVars: [
-      { name: 'DEBUG', value: 'true' },
-      { name: 'PORT', value: '8080' },
-    ],
-    secrets: [
-      {
-        name: 'GITHUB_API_TOKEN',
-        value: { secret: 'foo-bar', isFromStore: true },
-      },
-      { name: '', value: { secret: '', isFromStore: false } }, // Should be ignored
-    ],
-    cmd_arguments: '--debug --port 8080',
-  } as const satisfies FormSchemaRunFromRegistry
-
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
-  })
-
-  expect(mockCreateWorkload).toHaveBeenCalledWith({
-    body: expect.objectContaining({
-      cmd_arguments: ['--debug', '--port', '8080'],
-    }),
-  })
-})
-
-it('shows warning toast when server is not ready', async () => {
-  const mockSaveSecret = vi.fn()
-  const mockCreateWorkload = vi.fn()
-  const mockGetIsServerReady = vi.fn().mockResolvedValue(false)
-  const mockQueryClient = {
-    invalidateQueries: vi.fn(),
-  } as unknown as QueryClient
-
-  const SERVER: RegistryImageMetadata = {
-    name: 'test-server',
-    image: 'test-image',
-    transport: 'stdio',
-  }
-
-  const DATA: FormSchemaRunFromRegistry = {
-    serverName: 'Test Server',
-    envVars: [],
-    secrets: [],
-  }
-
-  await orchestrateRunRegistryServer({
-    createWorkload: mockCreateWorkload,
-    data: DATA,
-    getIsServerReady: mockGetIsServerReady,
-    queryClient: mockQueryClient,
-    saveSecret: mockSaveSecret,
-    server: SERVER,
-  })
-
-  expect(toast.loading).toHaveBeenCalledWith(
-    'Starting "Test Server"...',
-    expect.any(Object)
-  )
-  expect(toast.warning).toHaveBeenCalledWith(
-    'Server "Test Server" was created but may still be starting up. Check the servers list to monitor its status.',
-    expect.any(Object)
-  )
-  expect(toast.success).not.toHaveBeenCalled()
 })

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -80,13 +80,11 @@ export async function saveSecrets(
     // The arbitrary delay a UX/UI affordance to allow the user to see the progress
     // of the operation. This is not strictly necessary, but it helps to avoid
     // confusion when many secrets are being created in quick succession.
-    // The delay is between 100 and 500ms
+    // For single secret: 2000ms, for multiple secrets: random 200-1000ms
     await new Promise((resolve) =>
       setTimeout(
         resolve,
-        process.env.NODE_ENV === 'test'
-          ? 0
-          : Math.floor(Math.random() * 401) + 100
+        secretsCount === 1 ? 2000 : Math.floor(Math.random() * 801) + 200
       )
     )
     createdSecrets.push({

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -36,7 +36,7 @@ type CreateWorkloadFn = UseMutateAsyncFunction<
 /**
  * A utility function to filter out secrets that are not defined.
  */
-function getDefinedSecrets(
+export function getDefinedSecrets(
   secrets: FormSchemaRunFromRegistry['secrets']
 ): DefinedSecret[] {
   return secrets.reduce<DefinedSecret[]>((acc, { name, value }) => {
@@ -60,7 +60,7 @@ function getDefinedSecrets(
  * // NOTE: We add a short, arbitrary delay to allow the `toast` message that
  * displays progress to show up-to-date progress.
  */
-async function saveSecrets(
+export async function saveSecrets(
   secrets: PreparedSecret[],
   saveSecret: SaveSecretFn,
   toastID: string
@@ -135,7 +135,7 @@ async function saveSecrets(
  * Combines the registry server definition, the form fields, and the newly
  * created secrets from the secret store into a single request object.
  */
-function prepareCreateWorkloadData(
+export function prepareCreateWorkloadData(
   server: RegistryImageMetadata,
   data: FormSchemaRunFromRegistry,
   secrets: SecretsSecretParameter[] = []
@@ -167,7 +167,7 @@ type GroupedSecrets = {
  * existing secrets (from the registry). We need this separation to know which
  * secrets need to be encrypted and stored before creating the server workload.
  */
-function groupSecrets(secrets: DefinedSecret[]): {
+export function groupSecrets(secrets: DefinedSecret[]): {
   newSecrets: DefinedSecret[]
   existingSecrets: DefinedSecret[]
 } {

--- a/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
+++ b/renderer/src/features/registry-servers/lib/orchestrate-run-registry-server.tsx
@@ -1,35 +1,19 @@
 import {
-  getApiV1BetaSecretsDefaultKeys,
   type Options,
   type PostApiV1BetaSecretsDefaultKeysData,
-  type PostApiV1BetaWorkloadsData,
   type RegistryImageMetadata,
   type SecretsSecretParameter,
   type V1CreateRequest,
   type V1CreateSecretResponse,
-  type V1CreateWorkloadResponse,
 } from '@/common/api/generated'
-import { getApiV1BetaWorkloadsQueryKey } from '@/common/api/generated/@tanstack/react-query.gen'
-import { QueryClient, type UseMutateAsyncFunction } from '@tanstack/react-query'
-import { toast } from 'sonner'
 import type { FormSchemaRunFromRegistry } from './get-form-schema-run-from-registry'
-import { Progress } from '@/common/components/ui/progress'
-import { prepareSecretsWithoutNamingCollision } from '../../../common/lib/secrets/prepare-secrets-without-naming-collision'
-import { Link } from '@tanstack/react-router'
-import { Button } from '@/common/components/ui/button'
 import type { DefinedSecret, PreparedSecret } from '@/common/types/secrets'
+import type { UseMutateAsyncFunction } from '@tanstack/react-query'
 
 type SaveSecretFn = UseMutateAsyncFunction<
   V1CreateSecretResponse,
   string,
   Options<PostApiV1BetaSecretsDefaultKeysData>,
-  unknown
->
-
-type CreateWorkloadFn = UseMutateAsyncFunction<
-  V1CreateWorkloadResponse,
-  string,
-  Options<PostApiV1BetaWorkloadsData>,
   unknown
 >
 
@@ -63,7 +47,11 @@ export function getDefinedSecrets(
 export async function saveSecrets(
   secrets: PreparedSecret[],
   saveSecret: SaveSecretFn,
-  toastID: string
+  onSecretSuccess: (completedCount: number, secretsCount: number) => void,
+  onSecretError: (
+    error: string,
+    variables: Options<PostApiV1BetaSecretsDefaultKeysData>
+  ) => void
 ): Promise<SecretsSecretParameter[]> {
   const secretsCount: number = secrets.length
   let completedCount: number = 0
@@ -76,30 +64,11 @@ export async function saveSecrets(
       },
       {
         onError: (error, variables) => {
-          toast.error(
-            [
-              `Failed to encrypt secret "${variables.body.key}"`,
-              `\n${error}`,
-            ].join(''),
-            {
-              id: toastID,
-            }
-          )
+          onSecretError(error, variables)
         },
         onSuccess: () => {
           completedCount++
-          toast.loading(
-            <div className="w-full">
-              <p className="mb-2">
-                Encrypting secrets ({completedCount} of {secretsCount})...
-              </p>
-              <Progress
-                value={(completedCount / secretsCount) * 100}
-                className="w-full"
-              />
-            </div>,
-            { id: toastID }
-          )
+          onSecretSuccess(completedCount, secretsCount)
         },
       }
     )
@@ -182,177 +151,4 @@ export function groupSecrets(secrets: DefinedSecret[]): {
     },
     { newSecrets: [], existingSecrets: [] }
   )
-}
-
-/**
- * Orchestrates the "onSubmit" action for the "Run from Registry" form.
- */
-export async function orchestrateRunRegistryServer({
-  createWorkload,
-  data,
-  getIsServerReady,
-  queryClient,
-  saveSecret,
-  server,
-}: {
-  createWorkload: CreateWorkloadFn
-  data: FormSchemaRunFromRegistry
-  getIsServerReady: (serverName: string) => Promise<boolean>
-  queryClient: QueryClient
-  saveSecret: SaveSecretFn
-  server: RegistryImageMetadata
-}) {
-  const toastID: string = new Date(Date.now()).toISOString()
-
-  try {
-    let newlyCreatedSecrets: SecretsSecretParameter[] = []
-
-    // NOTE: Due to how we populate the names of the secrets in the form, we may
-    // have secrets with a `key` but no `value`. We filter those out.
-    const definedSecrets = getDefinedSecrets(data.secrets)
-
-    // Step 1: Group secrets into new and existing
-    // We need to know which secrets are new (not from the registry) and which are
-    // existing (already stored). This helps us handle the encryption and storage
-    // of secrets correctly.
-    const { existingSecrets, newSecrets } = groupSecrets(definedSecrets)
-
-    // Step 2: Fetch existing secrets & handle naming collisions
-    // We need an up-to-date list of secrets so we can handle any existing keys
-    // safely & correctly. This is done with a manual fetch call to avoid freshness issues /
-    // side-effects from the `useQuery` hook.
-    // In the event of a naming collision, we will append an incrementing number
-    // to the secret name, e.g. `MY_API_TOKEN` -> `MY_API_TOKEN_2`
-    const { data: fetchedSecrets } = await getApiV1BetaSecretsDefaultKeys({
-      throwOnError: true,
-    }).catch((e) => {
-      toast.error(
-        [
-          `An error occurred while starting the server.`,
-          'Could not retrieve secrets from the secret store.',
-          e instanceof Error ? `\n${e.message}` : null,
-        ].join('\n'),
-        {
-          id: toastID,
-        }
-      )
-      throw e
-    })
-    const preparedNewSecrets = prepareSecretsWithoutNamingCollision(
-      newSecrets,
-      fetchedSecrets
-    )
-
-    // Step 3: Encrypt secrets
-    // If there are secrets with values, create them in the secret store first.
-    // We need the data returned by the API to pass along with the "run workload" request.
-    if (preparedNewSecrets.length > 0) {
-      try {
-        newlyCreatedSecrets = await saveSecrets(
-          preparedNewSecrets,
-          saveSecret,
-          toastID
-        )
-      } catch (error) {
-        toast.error(
-          [
-            'An error occurred while starting the server.',
-            error instanceof Error ? `\n${error.message}` : null,
-          ].join(''),
-          {
-            id: toastID,
-          }
-        )
-        return
-      }
-    }
-
-    // Step 4: Create the MCP server workload
-    // Prepare the request data and send it to the API
-    // We pass the encrypted secrets along with the request.
-    const secretsForRequest: SecretsSecretParameter[] = [
-      ...newlyCreatedSecrets,
-      ...existingSecrets.map((secret) => ({
-        name: secret.value.secret,
-        target: secret.name,
-      })),
-    ]
-
-    const createRequest: V1CreateRequest = prepareCreateWorkloadData(
-      server,
-      data,
-      secretsForRequest
-    )
-
-    try {
-      await createWorkload({
-        body: createRequest,
-      })
-    } catch (error) {
-      console.debug('👉 error:', error)
-      toast.error(
-        [
-          'An error occurred while starting the server.',
-          error instanceof Error ? `\n${error.message}` : null,
-        ].join(''),
-        {
-          id: toastID,
-        }
-      )
-      return
-    }
-
-    // Step 5: Poll server status
-    // After the server is created, we need to wait for it to be ready.
-    // We use a polling function to check the server status.
-    // When the server is ready, we show feedback to the user.
-    toast.loading(`Starting "${data.serverName}"...`, {
-      duration: 30_000,
-      id: toastID,
-    })
-
-    if (await getIsServerReady(data.serverName)) {
-      // Invalidate queries to refresh server lists
-      await queryClient.invalidateQueries({
-        queryKey: getApiV1BetaWorkloadsQueryKey({ query: { all: true } }),
-      })
-
-      toast.success(`"${data.serverName}" started successfully.`, {
-        id: toastID,
-        duration: 5_000, // slightly longer than default
-        action: (
-          <Button asChild>
-            <Link
-              to="/"
-              search={{ newServerName: data.serverName }}
-              onClick={() => toast.dismiss(toastID)}
-              viewTransition={{ types: ['slide-left'] }}
-              className="ml-auto"
-            >
-              View
-            </Link>
-          </Button>
-        ),
-      })
-    } else {
-      toast.warning(
-        `Server "${data.serverName}" was created but may still be starting up. Check the servers list to monitor its status.`,
-        {
-          id: toastID,
-          duration: 2_000, // reset to default
-        }
-      )
-    }
-  } catch (error) {
-    toast.error(
-      [
-        'An error occurred while starting the server.',
-        error instanceof Error ? `\n${error.message}` : null,
-      ].join(''),
-      {
-        id: toastID,
-      }
-    )
-    throw error
-  }
 }

--- a/renderer/src/routes/registry.tsx
+++ b/renderer/src/routes/registry.tsx
@@ -21,7 +21,7 @@ export function Registry() {
     getApiV1BetaRegistryByNameServersOptions({ path: { name: 'default' } })
   )
   const { servers: serversList = [] } = data || {}
-  const { handleSubmit } = useRunFromRegistry()
+  const { handleSubmit, checkServerStatus } = useRunFromRegistry()
 
   return (
     <>
@@ -49,6 +49,7 @@ export function Registry() {
         <GridCardsRegistryServer
           servers={serversList}
           onSubmit={handleSubmit}
+          checkServerStatus={checkServerStatus}
         />
       )}
     </>

--- a/renderer/src/routes/registry.tsx
+++ b/renderer/src/routes/registry.tsx
@@ -1,7 +1,6 @@
 import { getApiV1BetaRegistryByNameServersOptions } from '@/common/api/generated/@tanstack/react-query.gen'
 import { createFileRoute } from '@tanstack/react-router'
 import { GridCardsRegistryServer } from '@/features/registry-servers/components/grid-cards-registry-server'
-import { useRunFromRegistry } from '@/features/registry-servers/hooks/use-run-from-registry'
 import { useSuspenseQuery } from '@tanstack/react-query'
 import { EmptyState } from '@/common/components/empty-state'
 import { ExternalLinkIcon } from 'lucide-react'
@@ -21,7 +20,6 @@ export function Registry() {
     getApiV1BetaRegistryByNameServersOptions({ path: { name: 'default' } })
   )
   const { servers: serversList = [] } = data || {}
-  const { handleSubmit, checkServerStatus } = useRunFromRegistry()
 
   return (
     <>
@@ -46,11 +44,7 @@ export function Registry() {
           illustration={IllustrationNoConnection}
         />
       ) : (
-        <GridCardsRegistryServer
-          servers={serversList}
-          onSubmit={handleSubmit}
-          checkServerStatus={checkServerStatus}
-        />
+        <GridCardsRegistryServer servers={serversList} />
       )}
     </>
   )


### PR DESCRIPTION
This is moving from toast only messages to inline form, that handle the possible errors directly on the submit of the form

new flow:

https://github.com/user-attachments/assets/172795b1-ba5a-435f-ae2e-996a833ac713


fine tunned error:

<img width="1046" alt="Screenshot 2025-07-04 at 16 51 05" src="https://github.com/user-attachments/assets/169455d2-da99-4cb1-b789-d7d7f4d80ffd" />


