### PR TITLE
chore(log): add electron-log in order to troubleshooting issues

### DIFF
--- a/main/src/auto-launch.ts
+++ b/main/src/auto-launch.ts
@@ -2,6 +2,7 @@ import { app } from 'electron'
 import path from 'node:path'
 import { existsSync, writeFileSync, unlinkSync, mkdirSync } from 'node:fs'
 import { homedir } from 'node:os'
+import log from './logger'
 
 interface DesktopEntry {
   Type: string
@@ -59,18 +60,18 @@ export function setAutoLaunch(enabled: boolean) {
       try {
         const desktopEntry = `[Desktop Entry]\n${createDesktopEntry(process.execPath)}`
         writeFileSync(desktopFile, desktopEntry)
-        console.log(`Created autostart file: ${desktopFile}`)
+        log.info(`Created autostart file: ${desktopFile}`)
       } catch (error) {
-        console.error('Failed to create autostart file:', error)
+        log.error('Failed to create autostart file: ', error)
       }
     } else {
       try {
         if (existsSync(desktopFile)) {
           unlinkSync(desktopFile)
-          console.log(`Removed autostart file: ${desktopFile}`)
+          log.info(`Removed autostart file: ${desktopFile}`)
         }
       } catch (error) {
-        console.error('Failed to remove autostart file:', error)
+        log.error('Failed to remove autostart file: ', error)
       }
     }
   }

--- a/main/src/logger.ts
+++ b/main/src/logger.ts
@@ -1,0 +1,29 @@
+import log from 'electron-log/main'
+import { app } from 'electron'
+import path from 'node:path'
+
+const isDevelopment = process.env.NODE_ENV === 'development'
+
+log.transports.file.resolvePathFn = () => {
+  const appName = app.getName()
+  console.log('appName', appName)
+  const logPath = app.getPath('logs')
+  return path.join(logPath, 'main.log')
+}
+
+log.transports.file.format = '[{y}-{m}-{d} {h}:{i}:{s}.{ms}] [{level}] {text}'
+log.transports.console.format = '{h}:{i}:{s}.{ms} > {text}'
+
+if (isDevelopment) {
+  log.transports.console.level = 'debug'
+  log.transports.file.level = 'info'
+} else {
+  log.transports.console.level = 'info'
+  log.transports.file.level = 'warn'
+}
+
+log.eventLogger.startLogging()
+
+log.initialize()
+
+export default log

--- a/main/src/logger.ts
+++ b/main/src/logger.ts
@@ -5,8 +5,6 @@ import path from 'node:path'
 const isDevelopment = process.env.NODE_ENV === 'development'
 
 log.transports.file.resolvePathFn = () => {
-  const appName = app.getName()
-  console.log('appName', appName)
   const logPath = app.getPath('logs')
   return path.join(logPath, 'main.log')
 }

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -31,6 +31,7 @@ import {
   isToolhiveRunning,
   binPath,
 } from './toolhive-manager'
+import log from './logger'
 
 Sentry.init({
   dsn: import.meta.env.VITE_SENTRY_DSN,
@@ -40,8 +41,8 @@ Sentry.init({
 declare const MAIN_WINDOW_VITE_DEV_SERVER_URL: string | undefined
 declare const MAIN_WINDOW_VITE_NAME: string
 
-console.log(`ToolHive binary path: ${binPath}`)
-console.log(`Binary file exists: ${existsSync(binPath)}`)
+log.info(`ToolHive binary path: ${binPath}`)
+log.info(`Binary file exists: ${existsSync(binPath)}`)
 
 // this implements auto-update
 updateElectronApp()
@@ -56,7 +57,7 @@ app.on('ready', () => {
       return
     }
 
-    console.debug('Simulating a new release for testing purposes')
+    log.info('Simulating a new release for testing purposes')
     mainWindow.webContents.send('update-downloaded')
   }, 2000)
 })
@@ -66,13 +67,12 @@ autoUpdater.on('update-downloaded', () => {
     return
   }
 
-  console.log('Update downloaded — sending to renderer')
+  log.info('Update downloaded — sending to renderer')
   mainWindow.webContents.send('update-downloaded')
 })
 
 autoUpdater.on('error', (message) => {
-  console.error('There was a problem updating the application')
-  console.error(message)
+  log.error('There was a problem updating the application: ', message)
 })
 
 autoUpdater.checkForUpdates()
@@ -87,7 +87,7 @@ export async function blockQuit(source: string, event?: Electron.Event) {
   if (tearingDown) return
   tearingDown = true
   isQuitting = true
-  console.info(`[${source}] initiating graceful teardown...`)
+  log.info(`[${source}] initiating graceful teardown...`)
 
   if (event) {
     event.preventDefault()
@@ -101,7 +101,7 @@ export async function blockQuit(source: string, event?: Electron.Event) {
       await stopAllServers(binPath, port)
     }
   } catch (err) {
-    console.error('Teardown failed:', err)
+    log.error('Teardown failed: ', err)
   } finally {
     // Stop the embedded ToolHive server
     stopToolhive()
@@ -117,12 +117,12 @@ export async function blockQuit(source: string, event?: Electron.Event) {
 const gotTheLock = app.requestSingleInstanceLock()
 
 if (!gotTheLock) {
-  console.log('Another instance is already running. Exiting...')
+  log.info('Another instance is already running. Exiting...')
   app.quit()
 } else {
   app.on('second-instance', () => {
     // Someone tried to run a second instance, focus our window instead
-    console.log('Second instance attempted, focusing existing window')
+    log.info('Second instance attempted, focusing existing window')
     if (mainWindow) {
       if (mainWindow.isMinimized()) mainWindow.restore()
       mainWindow.focus()
@@ -223,11 +223,11 @@ app.whenReady().then(async () => {
   // Initialize tray first
   try {
     tray = initTray({ toolHiveIsRunning: false }) // Start with false, will update after ToolHive starts
-    console.log('System tray initialized successfully')
+    log.info('System tray initialized successfully')
     // Setup application menu
     createApplicationMenu(tray)
   } catch (error) {
-    console.error('Failed to initialize system tray:', error)
+    log.error('Failed to initialize system tray: ', error)
   }
 
   // Start ToolHive with tray reference
@@ -262,7 +262,7 @@ app.whenReady().then(async () => {
         tray.destroy()
         tray = initTray({ toolHiveIsRunning: isToolhiveRunning() })
       } catch (error) {
-        console.error('Failed to update tray after theme change:', error)
+        log.error('Failed to update tray after theme change: ', error)
       }
     }
   })
@@ -290,7 +290,7 @@ app.on('will-quit', (e) => blockQuit('will-quit', e))
     if (tearingDown) return
     tearingDown = true
     isQuitting = true
-    console.log(`[${sig}] delaying exit for teardown…`)
+    log.info(`[${sig}] delaying exit for teardown...`)
     try {
       const port = getToolhivePort()
       if (port) {
@@ -386,7 +386,7 @@ ipcMain.handle('restart-toolhive', async () => {
     await restartToolhive(tray || undefined)
     return { success: true }
   } catch (error) {
-    console.error('Failed to restart ToolHive:', error)
+    log.error('Failed to restart ToolHive: ', error)
     return {
       success: false,
       error: error instanceof Error ? error.message : 'Unknown error',

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -45,7 +45,7 @@ log.info(`ToolHive binary path: ${binPath}`)
 log.info(`Binary file exists: ${existsSync(binPath)}`)
 
 // this implements auto-update
-updateElectronApp()
+updateElectronApp({ logger: log })
 
 app.on('ready', () => {
   setTimeout(() => {

--- a/main/src/menu.ts
+++ b/main/src/menu.ts
@@ -1,6 +1,7 @@
 import { Menu, app } from 'electron'
 import { getAutoLaunchStatus, setAutoLaunch } from './auto-launch'
 import { updateTrayStatus } from './system-tray'
+import log from './logger'
 
 function createAutoLaunchItem(
   accelerator: string,
@@ -20,7 +21,7 @@ function createAutoLaunchItem(
         }
         createApplicationMenu(trayRef)
       } catch (error) {
-        console.error('Failed to toggle auto-launch:', error)
+        log.error('Failed to toggle auto-launch: ', error)
       }
     },
   }

--- a/main/src/system-tray.ts
+++ b/main/src/system-tray.ts
@@ -2,6 +2,7 @@ import { Menu, Tray, app, nativeImage, BrowserWindow } from 'electron'
 import path from 'node:path'
 import { getAutoLaunchStatus, setAutoLaunch } from './auto-launch'
 import { createApplicationMenu } from './menu'
+import log from './logger'
 
 ///////////////////////////////////////////////////
 // Tray icon
@@ -53,7 +54,7 @@ const createTrayWithSetup =
       setupFn(tray, toolHiveIsRunning)
       return tray
     } catch (error) {
-      console.error('Failed to create tray:', error)
+      log.error('Failed to create tray: ', error)
       throw error
     }
   }
@@ -123,7 +124,7 @@ const handleStartOnLogin = async (
     // Update the application menu to reflect the new state
     createApplicationMenu(currentTray)
   } catch (error) {
-    console.error('Failed to toggle auto-launch:', error)
+    log.error('Failed to toggle auto-launch: ', error)
   }
 }
 
@@ -239,6 +240,6 @@ export const updateTrayStatus = (tray: Tray, toolHiveIsRunning: boolean) => {
   try {
     setupTrayMenu(tray, toolHiveIsRunning)
   } catch (error) {
-    console.error('Failed to update tray status:', error)
+    log.error('Failed to update tray status: ', error)
   }
 }

--- a/package.json
+++ b/package.json
@@ -114,6 +114,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "electron-log": "^5.4.1",
     "electron-squirrel-startup": "^1.0.1",
     "electron-store": "^10.1.0",
     "lucide-react": "^0.523.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -89,6 +89,9 @@ importers:
       cmdk:
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      electron-log:
+        specifier: ^5.4.1
+        version: 5.4.1
       electron-squirrel-startup:
         specifier: ^1.0.1
         version: 1.0.1
@@ -3276,6 +3279,10 @@ packages:
     engines: {node: '>= 10.0.0'}
     os: [darwin, linux]
     hasBin: true
+
+  electron-log@5.4.1:
+    resolution: {integrity: sha512-QvisA18Z++8E3Th0zmhUelys9dEv7aIeXJlbFw3UrxCc8H9qSRW0j8/ooTef/EtHui8tVmbKSL+EIQzP9GoRLg==}
+    engines: {node: '>= 14'}
 
   electron-squirrel-startup@1.0.1:
     resolution: {integrity: sha512-sTfFIHGku+7PsHLJ7v0dRcZNkALrV+YEozINTW8X1nM//e5O3L+rfYuvSW00lmGHnYmUjARZulD8F2V8ISI9RA==}
@@ -9617,6 +9624,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
     optional: true
+
+  electron-log@5.4.1: {}
 
   electron-squirrel-startup@1.0.1:
     dependencies:

--- a/renderer/src/common/components/error/connection-refused-error.tsx
+++ b/renderer/src/common/components/error/connection-refused-error.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/common/components/ui/button'
 import { BaseErrorScreen } from './base-error-screen'
 import { IllustrationPackage } from '../illustrations/illustration-package'
 import { withMinimumDelay } from './utils'
+import log from 'electron-log/renderer'
 
 interface ExternalLinkButtonProps {
   href: string
@@ -42,7 +43,7 @@ export function ConnectionRefusedError() {
     isError: isRestartError,
   } = useMutation({
     mutationFn: async () => {
-      console.log('Container engines are now available, restarting ToolHive...')
+      log.info('Container engines are now available, restarting ToolHive...')
       const result = await withMinimumDelay(
         window.electronAPI.restartToolhive,
         1200
@@ -51,14 +52,14 @@ export function ConnectionRefusedError() {
     },
     onSuccess: (result) => {
       if (result.success) {
-        console.log('ToolHive restarted successfully')
+        log.info('ToolHive restarted successfully')
         window.location.reload()
       } else {
-        console.error('Failed to restart ToolHive:', result.error)
+        log.error('Failed to restart ToolHive: ', result.error)
       }
     },
     onError: (error) => {
-      console.error('Error restarting ToolHive:', error)
+      log.error('Error restarting ToolHive: ', error)
     },
   })
 

--- a/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
+++ b/renderer/src/features/registry-servers/components/grid-cards-registry-server.tsx
@@ -37,13 +37,6 @@ export function GridCardsRegistryServer({
   const handleModalSubmit = (data: FormSchemaRunFromRegistry) => {
     if (selectedServer && onSubmit) {
       onSubmit(selectedServer, data)
-    } else {
-      // Fallback for when onSubmit is not provided
-      console.log('Installing server:', {
-        serverName: data.serverName,
-        sourceServer: selectedServer,
-        envVars: data.envVars,
-      })
     }
   }
 

--- a/renderer/src/renderer.tsx
+++ b/renderer/src/renderer.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from '@radix-ui/react-tooltip'
 import * as Sentry from '@sentry/electron/renderer'
 import { ThemeProvider } from './common/components/theme/theme-provider'
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools'
+import log from 'electron-log/renderer'
 
 import './index.css'
 import { ConfirmProvider } from './common/contexts/confirm/provider'
@@ -58,7 +59,7 @@ const router = createRouter({
 })
 
 if (!window.electronAPI || !window.electronAPI.getToolhivePort) {
-  console.error('ToolHive port API not available in renderer')
+  log.error('ToolHive port API not available in renderer')
 }
 
 ;(async () => {
@@ -67,7 +68,7 @@ if (!window.electronAPI || !window.electronAPI.getToolhivePort) {
     const baseUrl = `http://localhost:${port}`
     client.setConfig({ baseUrl })
   } catch (e) {
-    console.error('Failed to get ToolHive port from main process', e)
+    log.error('Failed to get ToolHive port from main process: ', e)
     throw e
   }
 

--- a/renderer/src/routes/__root.tsx
+++ b/renderer/src/routes/__root.tsx
@@ -21,6 +21,7 @@ import '@fontsource/atkinson-hyperlegible/700.css'
 import '@fontsource/atkinson-hyperlegible/400-italic.css'
 import '@fontsource/atkinson-hyperlegible/700-italic.css'
 import '@fontsource-variable/inter/wght.css'
+import log from 'electron-log/renderer'
 
 async function setupSecretProvider(queryClient: QueryClient) {
   const createEncryptedProvider = () =>
@@ -68,7 +69,7 @@ export const Route = createRootRouteWithContext<{
   errorComponent: ({ error }) => <Error error={error} />,
   notFoundComponent: () => <NotFound />,
   onError: (error) => {
-    console.error(error)
+    log.error(error)
   },
   beforeLoad: async ({ context: { queryClient } }) => {
     await queryClient.ensureQueryData({
@@ -76,7 +77,7 @@ export const Route = createRootRouteWithContext<{
       queryFn: async () => {
         const res = await window.electronAPI.isToolhiveRunning()
         if (!res) {
-          console.error('Error ToolHive is not running')
+          log.error('Error ToolHive is not running')
         }
         return res
       },

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,1 +1,1 @@
-export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.1.2'
+export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.1.1'

--- a/utils/constants.ts
+++ b/utils/constants.ts
@@ -1,1 +1,1 @@
-export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.1.1'
+export const TOOLHIVE_VERSION = process.env.THV_VERSION ?? 'v0.1.2'

--- a/vitest.setup.ts
+++ b/vitest.setup.ts
@@ -21,6 +21,15 @@ beforeAll(() => {
     fetch,
   })
 
+  vi.mock('electron-log/renderer', () => ({
+    default: new Proxy(
+      {},
+      {
+        get: () => vi.fn(() => new Proxy({}, { get: () => vi.fn() })),
+      }
+    ),
+  }))
+
   window.HTMLElement.prototype.scrollIntoView = function () {}
 
   global.ResizeObserver = class ResizeObserver {


### PR DESCRIPTION
Used [electron-log](https://github.com/megahertz/electron-log) replacing `console` with `log` fn.

The log will be saved into the filesystem:

- on Linux: ~/.config/{app name}/logs/main.log
- on macOS: ~/Library/Logs/{app name}/main.log
- on Windows: %USERPROFILE%\AppData\Roaming\{app name}\logs\main.log

___
nit: we can improve or replace later, but we got some issues using directly the dmg download from github repo, that we cannot reproduce locally, so it would helpful to have some additional info here.

`Logs with info|warn|error`

<img width="1832" alt="Screenshot 2025-07-04 at 15 09 55" src="https://github.com/user-attachments/assets/9560bf3c-9c8a-43f7-84da-43b5d5c809d4" />

`Logs in both thv serve and logs file`

<img width="1666" alt="Screenshot 2025-07-04 at 15 07 05" src="https://github.com/user-attachments/assets/e92e2fd7-fe75-420f-85d7-c98e92e75d1b" />
