### PR TITLE
feat: allow minimizing to tray from the GUI

### DIFF
--- a/renderer/src/common/components/settings/settings-dropdown.tsx
+++ b/renderer/src/common/components/settings/settings-dropdown.tsx
@@ -30,6 +30,12 @@ export function SettingsDropdown({ className }: { className?: string }) {
     setAutoLaunch(!autoLaunchStatus)
   }
 
+  const handleMinimizeToTray = () => {
+    if (window.electronAPI) {
+      window.electronAPI.hideApp()
+    }
+  }
+
   const handleQuit = async () => {
     const confirmed = await confirmQuit()
     if (confirmed && window.electronAPI) {
@@ -61,6 +67,12 @@ export function SettingsDropdown({ className }: { className?: string }) {
         >
           <span>Start on login</span>
           {autoLaunchStatus && <Check className="h-4 w-4" />}
+        </DropdownMenuItem>
+        <DropdownMenuItem
+          onClick={handleMinimizeToTray}
+          className="cursor-pointer"
+        >
+          <span>Minimize to Tray</span>
         </DropdownMenuItem>
         <DropdownMenuItem
           variant="destructive"


### PR DESCRIPTION
![Screenshot_select-area_20250704152010](https://github.com/user-attachments/assets/2c8b9363-8dba-4d24-bdee-282b3494e8bc)

just adds an option to minimize to tray from the main window. this should reduce the chance of confusion/annoyance when the user is trying to get rid of the main window without killing the MCPs.