### PR TITLE
fix: minor label consistency and wording updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ Start by installing a simple MCP server from the registry:
 
    ![ToolHive registry](docs/images/quickstart-2.webp)
 
-3. Click **Install Server** to start the server.
+3. Click **Install server** to start the server.
 
 4. Once the server is running, click **View** on the notification or open the
    **Installed** tab to see its status.

--- a/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
+++ b/renderer/src/features/mcp-servers/components/__tests__/dialog-form-run-mcp-command.test.tsx
@@ -57,7 +57,7 @@ it('is able to run an MCP server while omitting optional fields', async () => {
     'ghcr.io/github/github-mcp-server'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
   expect(onSubmitMock).toHaveBeenCalledWith({
     name: 'foo-bar',
     transport: 'stdio',
@@ -133,7 +133,7 @@ it('is able to run an MCP server with docker', async () => {
     'foo-bar'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   const payload = onSubmitMock.mock.calls[0]?.[0]
   expect(payload).toBeDefined()
@@ -236,7 +236,7 @@ it('is able to run an MCP server with npx', async () => {
     'foo-bar'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   const payload = onSubmitMock.mock.calls[0]?.[0]
   expect(payload).toBeDefined()
@@ -340,7 +340,7 @@ it('is able to run an MCP server with uvx', async () => {
     'foo-bar'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   const payload = onSubmitMock.mock.calls[0]?.[0]
   expect(payload).toBeDefined()
@@ -444,7 +444,7 @@ it('is able to run an MCP server with go', async () => {
     'foo-bar'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Submit' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   const payload = onSubmitMock.mock.calls[0]?.[0]
   expect(payload).toBeDefined()

--- a/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
+++ b/renderer/src/features/mcp-servers/components/dialog-form-run-mcp-command.tsx
@@ -75,7 +75,7 @@ export function DialogFormRunMcpServerWithCommand({
             </div>
 
             <DialogFooter className="p-6">
-              <Button type="submit">Submit</Button>
+              <Button type="submit">Install server</Button>
             </DialogFooter>
           </form>
         </Form>

--- a/renderer/src/features/mcp-servers/components/form-fields-run-mcp-command.tsx
+++ b/renderer/src/features/mcp-servers/components/form-fields-run-mcp-command.tsx
@@ -123,7 +123,7 @@ export function FormFieldsRunMcpCommand({
               </div>
               <FormControl>
                 <Input
-                  placeholder="e.g. ghcr.io/acme-corp/my-awesome-server"
+                  placeholder="e.g. ghcr.io/acme-corp/my-awesome-server:latest"
                   defaultValue={field.value}
                   onChange={(e) => field.onChange(e.target.value)}
                   name={field.name}
@@ -192,7 +192,7 @@ export function FormFieldsRunMcpCommand({
                   </div>
                   <Input
                     className="rounded-l-none"
-                    placeholder="e.g. my-awesome-server"
+                    placeholder="e.g. my-awesome-server@latest"
                     defaultValue={field.value}
                     onChange={(e) => field.onChange(e.target.value)}
                     name={field.name}

--- a/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
+++ b/renderer/src/features/registry-servers/components/__tests__/form-run-from-registry.test.tsx
@@ -100,7 +100,7 @@ it('allows form submission with "inline" secret', async () => {
   })
 
   await userEvent.type(
-    screen.getByLabelText('Server Name', { selector: 'input' }),
+    screen.getByLabelText('Server name', { selector: 'input' }),
     'my-awesome-server',
     {
       initialSelectionStart: 0,
@@ -117,7 +117,7 @@ it('allows form submission with "inline" secret', async () => {
     'my-awesome-env-var'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install Server' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   await waitFor(() => {
     expect(onSubmit).toHaveBeenCalledWith({
@@ -178,7 +178,7 @@ it('allows form submission with secret from store', async () => {
   })
 
   await userEvent.type(
-    screen.getByLabelText('Server Name', { selector: 'input' }),
+    screen.getByLabelText('Server name', { selector: 'input' }),
     'my-awesome-server',
     {
       initialSelectionStart: 0,
@@ -199,7 +199,7 @@ it('allows form submission with secret from store', async () => {
     'my-awesome-env-var'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install Server' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   await waitFor(() => {
     expect(onSubmit).toHaveBeenCalledWith({
@@ -248,7 +248,7 @@ it('allows form submission without optional vars', async () => {
   })
 
   await userEvent.type(
-    screen.getByLabelText('Server Name', { selector: 'input' }),
+    screen.getByLabelText('Server name', { selector: 'input' }),
     'my-awesome-server',
     {
       initialSelectionStart: 0,
@@ -256,7 +256,7 @@ it('allows form submission without optional vars', async () => {
     }
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install Server' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   await waitFor(() => {
     expect(onSubmit).toHaveBeenCalledWith({
@@ -307,7 +307,7 @@ it('allows form submission with populated required vars', async () => {
   })
 
   await userEvent.type(
-    screen.getByLabelText('Server Name', { selector: 'input' }),
+    screen.getByLabelText('Server name', { selector: 'input' }),
     'my-awesome-server',
     {
       initialSelectionStart: 0,
@@ -324,7 +324,7 @@ it('allows form submission with populated required vars', async () => {
     'my-awesome-env-var'
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install Server' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   await waitFor(() => {
     expect(onSubmit).toHaveBeenCalledWith({
@@ -373,7 +373,7 @@ it('renders validation errors when required variables missing', async () => {
   })
 
   await userEvent.type(
-    screen.getByLabelText('Server Name', { selector: 'input' }),
+    screen.getByLabelText('Server name', { selector: 'input' }),
     'my-awesome-server',
     {
       initialSelectionStart: 0,
@@ -381,7 +381,7 @@ it('renders validation errors when required variables missing', async () => {
     }
   )
 
-  await userEvent.click(screen.getByRole('button', { name: 'Install Server' }))
+  await userEvent.click(screen.getByRole('button', { name: 'Install server' }))
 
   await waitFor(() => {
     expect(onSubmit).not.toHaveBeenCalled()

--- a/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
+++ b/renderer/src/features/registry-servers/components/form-run-from-registry.tsx
@@ -282,7 +282,7 @@ export function FormRunFromRegistry({
                 name="serverName"
                 render={({ field }) => (
                   <FormItem className="mb-10">
-                    <FormLabel>Server Name</FormLabel>
+                    <FormLabel>Server name</FormLabel>
                     <FormDescription>
                       Choose a unique name for this server instance
                     </FormDescription>
@@ -372,7 +372,7 @@ export function FormRunFromRegistry({
               >
                 Cancel
               </Button>
-              <Button type="submit">Install Server</Button>
+              <Button type="submit">Install server</Button>
             </DialogFooter>
           </form>
         </Form>

--- a/renderer/src/features/secrets/components/__tests__/dialog-form-secret.test.tsx
+++ b/renderer/src/features/secrets/components/__tests__/dialog-form-secret.test.tsx
@@ -67,5 +67,5 @@ it('should not call onSubmit when form has validation errors', async () => {
   })
 
   expect(screen.getByText('Secret name is required')).toBeInTheDocument()
-  expect(screen.getByText('Secret contents is required')).toBeInTheDocument()
+  expect(screen.getByText('Secret value is required')).toBeInTheDocument()
 })

--- a/renderer/src/features/secrets/components/dialog-form-secret.tsx
+++ b/renderer/src/features/secrets/components/dialog-form-secret.tsx
@@ -25,12 +25,12 @@ import { useState } from 'react'
 
 const createSecretSchema = z.object({
   key: z.string().min(1, 'Secret name is required'),
-  value: z.string().min(1, 'Secret contents is required'),
+  value: z.string().min(1, 'Secret value is required'),
 })
 
 const editSecretSchema = z.object({
   key: z.string().optional(),
-  value: z.string().min(1, 'Secret contents is required'),
+  value: z.string().min(1, 'Secret value is required'),
 })
 
 type SecretFormData = z.infer<typeof createSecretSchema>
@@ -106,9 +106,7 @@ export function DialogFormSecret({
 
 function SecretForm({ form, isEditMode, onSubmit, onCancel }: SecretFormProps) {
   const [showPassword, setShowPassword] = useState(false)
-  const secretContentsLabel = isEditMode
-    ? 'Replacement secret'
-    : 'Secret contents'
+  const secretContentsLabel = isEditMode ? 'New value' : 'Secret value'
   const submitButtonText = isEditMode ? 'Update' : 'Save'
 
   const handleFormSubmit = (data: SecretFormData) => {

--- a/renderer/src/routes/__tests__/registry.test.tsx
+++ b/renderer/src/routes/__tests__/registry.test.tsx
@@ -85,7 +85,7 @@ it('launches dialog with form when clicking on server', async () => {
   })
 
   expect(
-    screen.getByLabelText('Server Name', { selector: 'input' })
+    screen.getByLabelText('Server name', { selector: 'input' })
   ).toBeVisible()
 
   expect(screen.getByLabelText('Secrets', { selector: 'input' })).toBeVisible()

--- a/renderer/src/routes/secrets.tsx
+++ b/renderer/src/routes/secrets.tsx
@@ -57,7 +57,7 @@ export function Secrets() {
             setSecretKey('')
           }}
         >
-          <PlusIcon /> Add Secret
+          <PlusIcon /> Add secret
         </Button>
       </div>
 


### PR DESCRIPTION
Some small updates to labels:

* Fixed some capitalization inconsistencies
* Made the custom server submission button label consistent with adding from registry ("Install server", not "Submit")
* Added `:latest` / `@latest` to example image/package inputs
* On the update secret modal, updated some strings that didn't sound right to me:
  * "Replacement secret" -> "New value"
  * "Secret contents" -> "Secret value